### PR TITLE
Fix metadata restore paths and per-client last fetch display

### DIFF
--- a/app.py
+++ b/app.py
@@ -2973,6 +2973,29 @@ def get_last_fetch_date(credential_name: str) -> Optional[str]:
         return None
 
 
+def _get_fetch_tracking_key(credential_name: str = '', credential_vat: str = '') -> str:
+    """Return stable key for last-fetch tracking (prefer VAT when available)."""
+    vat = str(credential_vat or '').strip()
+    if vat:
+        return vat
+
+    name = str(credential_name or '').strip()
+    if not name:
+        return ''
+
+    try:
+        creds = load_credentials() or []
+        found = next((c for c in creds if str(c.get('name', '')).strip() == name), None)
+        if found:
+            found_vat = str(found.get('vat', '')).strip()
+            if found_vat:
+                return found_vat
+    except Exception:
+        pass
+
+    return name
+
+
 def set_last_fetch_date(credential_name: str, date_str: Optional[str] = None) -> bool:
     """
     Set the last fetch date for a credential in fiscal_meta.json.
@@ -6653,10 +6676,15 @@ def api_last_fetch_date():
     """
     try:
         credential_name = (request.args.get("credential") or "").strip()
-        if not credential_name:
+        credential_vat = (request.args.get("vat") or "").strip()
+        if not credential_name and not credential_vat:
             return jsonify({"last_fetch_date": None}), 400
-        
-        last_date = get_last_fetch_date(credential_name)
+
+        fetch_key = _get_fetch_tracking_key(credential_name, credential_vat)
+        last_date = get_last_fetch_date(fetch_key) if fetch_key else None
+        if not last_date and credential_name and fetch_key != credential_name:
+            # Backward compatibility: older installs may have written by credential name.
+            last_date = get_last_fetch_date(credential_name)
         
         # Format for display if available
         if last_date:
@@ -6703,28 +6731,21 @@ def client_db_info():
     { exists: bool, filename: str|null, uploaded_at: str|null, total_rows: int, new_rows: int, updated_rows: int }
     """
     try:
-        # prefer per-user group meta when authenticated
+        # Always resolve against the active group first to avoid cross-group metadata mismatches.
+        target_base = get_group_base_dir()
+        requested_group = (request.args.get('group') or '').strip()
         try:
             from flask_login import current_user
-            target_base = DATA_DIR
-            requested_group = (request.args.get('group') or '').strip()
-            if getattr(current_user, 'is_authenticated', False):
+            if requested_group and getattr(current_user, 'is_authenticated', False):
                 user_groups = getattr(current_user, 'groups', [])
-                if requested_group:
-                    grp = None
-                    for g in user_groups:
-                        if g.name == requested_group:
-                            grp = g
-                            break
-                    if not grp:
-                        return jsonify({'ok': False, 'error': 'Δεν έχετε πρόσβαση στην επιλεγμένη ομάδα.'}), 403
-                    target_base = os.path.join(BASE_DIR, 'data', grp.data_folder or '')
-                else:
-                    if len(user_groups) == 1:
-                        target_base = os.path.join(BASE_DIR, 'data', user_groups[0].data_folder or '')
-            meta = read_client_meta(base_dir=target_base)
+                grp = next((g for g in user_groups if g.name == requested_group), None)
+                if not grp:
+                    return jsonify({'ok': False, 'error': 'Δεν έχετε πρόσβαση στην επιλεγμένη ομάδα.'}), 403
+                target_base = os.path.join(BASE_DIR, 'data', grp.data_folder or '')
         except Exception:
-            meta = read_client_meta()
+            pass
+
+        meta = read_client_meta(base_dir=target_base)
         counts = {'total_rows': 0, 'new_rows': 0, 'updated_rows': 0}
 
         if meta:
@@ -6759,9 +6780,9 @@ def client_db_info():
                            **counts), 200
 
         # fallback: if any client_db.* exists but no meta file
-        for existing in os.listdir(get_group_base_dir()):
+        for existing in os.listdir(target_base):
             if existing.startswith('client_db') and os.path.splitext(existing)[1].lower() in ALLOWED_CLIENT_EXT:
-                p = os.path.join(get_group_base_dir(), existing)
+                p = os.path.join(target_base, existing)
                 try:
                     mtime = _dt.utcfromtimestamp(os.path.getmtime(p)).replace(microsecond=0).isoformat() + 'Z'
                     counts.update({'total_rows': 0, 'new_rows': 0, 'updated_rows': 0})
@@ -7111,9 +7132,10 @@ def fetch():
                 if append_summary_to_customer_file(s, vat):
                     added_summaries += 1
 
-            # Track last fetch date for this credential
-            if selected:
-                set_last_fetch_date(selected)
+            # Track last fetch date for this selected client (prefer VAT key).
+            fetch_key = _get_fetch_tracking_key(selected, vat)
+            if fetch_key:
+                set_last_fetch_date(fetch_key)
             
             # Log fetch operation as structured activity (so admin UI shows details)
             try:
@@ -11372,4 +11394,3 @@ if __name__ == "__main__":
     port = int(os.getenv("PORT", "5001"))
     debug_flag = True
     app.run(host="0.0.0.0", port=port, debug=debug_flag, use_reloader=True)
-

--- a/firebase_config.py
+++ b/firebase_config.py
@@ -758,13 +758,32 @@ def firebase_pull_group_to_local(group_name: str, local_data_root: str = None) -
         
         def _get_file_name_with_extension(key_name):
             """
-            Convert key name to proper file name with extension.
-            E.g., 'credentials_settings_json' -> 'credentials_settings.json'
-                  '12345679_2024_invoices_xlsx' -> '12345679_2024_invoices.xlsx'
+            Convert Firebase key names back to local file names.
+            Handles both unsanitized keys (foo.xlsx.meta_json) and sanitized ones
+            produced by RTDB key rules (foo_xlsx_meta_json).
             """
             key_str = str(key_name).lstrip('/')
-            
-            # Map of suffixes to extensions
+
+            # Handle sanitized metadata keys first (critical for CoA/client_db metadata).
+            special_suffixes = {
+                '_xlsx_meta_json': '.xlsx.meta.json',
+                '_xls_meta_json': '.xls.meta.json',
+                '_csv_meta_json': '.csv.meta.json',
+            }
+            for suffix, ext in special_suffixes.items():
+                if key_str.endswith(suffix):
+                    return f"{key_str[:-len(suffix)]}{ext}"
+
+            # Also handle unsanitized metadata keys.
+            unsanitized_suffixes = {
+                '.xlsx.meta_json': '.xlsx.meta.json',
+                '.xls.meta_json': '.xls.meta.json',
+                '.csv.meta_json': '.csv.meta.json',
+            }
+            for suffix, ext in unsanitized_suffixes.items():
+                if key_str.endswith(suffix):
+                    return f"{key_str[:-len(suffix)]}{ext}"
+
             extension_map = {
                 '_json': '.json',
                 '_xlsx': '.xlsx',
@@ -775,15 +794,11 @@ def firebase_pull_group_to_local(group_name: str, local_data_root: str = None) -
                 '_xml': '.xml',
                 '_log': '.log',
             }
-            
-            # Check for known extensions at the end
+
             for suffix, ext in extension_map.items():
                 if key_str.endswith(suffix):
-                    # Replace the suffix with the extension
-                    base_name = key_str[:-len(suffix)]
-                    return f"{base_name}{ext}"
-            
-            # If no extension found, return as-is
+                    return f"{key_str[:-len(suffix)]}{ext}"
+
             return key_str
         
         # compute total files to process for progress estimation

--- a/templates/fetch.html
+++ b/templates/fetch.html
@@ -50,7 +50,7 @@
             {% for c in credentials %}
               {%- set selected_val = (request.form.get('use_credential') == c.name) or (not request.form.get('use_credential') and active_credential == c.name) -%}
               {%- set label = c.name ~ (c.vat and (' (' ~ c.vat ~ ')') or '') -%}
-              <option value="{{ c.name }}" {% if selected_val %}selected{% endif %}>{{ label }}</option>
+              <option value="{{ c.name }}" data-vat="{{ c.vat or "" }}" {% if selected_val %}selected{% endif %}>{{ label }}</option>
             {% endfor %}
           </select>
         </div>
@@ -208,7 +208,11 @@ document.addEventListener("DOMContentLoaded", function() {
       return;
     }
     try {
-      const res = await fetch('/api/last_fetch_date?credential=' + encodeURIComponent(credentialName));
+      const selectedOption = credentialSelect.options[credentialSelect.selectedIndex];
+      const vat = (selectedOption && selectedOption.dataset && selectedOption.dataset.vat) ? selectedOption.dataset.vat.trim() : '';
+      const query = new URLSearchParams({ credential: credentialName });
+      if (vat) query.set('vat', vat);
+      const res = await fetch('/api/last_fetch_date?' + query.toString());
       if (res.ok) {
         const data = await res.json();
         if (data.last_fetch_date) {


### PR DESCRIPTION
### Motivation
- Fix warnings like `Metadata file not found` after Firebase sync caused by sanitized RTDB keys being materialized with incorrect filenames (e.g. CoA metadata being renamed). 
- Ensure `client_db` info and row counts are read from the correct active-group directory to avoid showing `total_rows: 0` from the wrong path.
- Make the “Τελευταία λήψη” / last-fetch UI show the timestamp for the selected client (prefer VAT) rather than a generic group credential, while keeping backward compatibility.

### Description
- Added `_get_fetch_tracking_key` in `app.py` to resolve a stable tracking key that prefers the credential VAT and falls back to credential name, and used it when setting and reading last-fetch timestamps via `set_last_fetch_date` / `api_last_fetch_date`.
- Updated the fetch flow in `app.py` to store last-fetch using the resolved fetch key instead of raw credential name when available.
- Modified `/client_db_info` in `app.py` to resolve `target_base` against the active group directory by default and to use that same `target_base` for the fallback scan, preventing cross-group metadata mismatches.
- Fixed `firebase_pull_group_to_local` in `firebase_config.py` to reconstruct metadata filenames correctly from sanitized Firebase keys by handling patterns like `*_xlsx_meta_json` -> `*.xlsx.meta.json` (and similar for `.xls`/`.csv`).
- Updated `templates/fetch.html` to include `data-vat` on credential options and to send the `vat` as a query parameter to `api_last_fetch_date` so the API can resolve per-client last-fetch keys.

### Testing
- Compiled key modules with `python3 -m py_compile app.py firebase_config.py` and the compilation completed successfully. 
- Performed automated syntax checks via `python3 -m py_compile` as above and confirmed no syntax errors. 
- Basic smoke verification: template JS updated to include `vat` in the `api_last_fetch_date` request and server-side handlers return formatted `last_fetch_date` when present (validated by code path inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b3f3c79e4832898ae490a7467c91f)