### PR TITLE
Enforce εγγυοδοσία 0% VAT, improve backup labels and client_db upload/metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -2973,6 +2973,29 @@ def get_last_fetch_date(credential_name: str) -> Optional[str]:
         return None
 
 
+def _get_fetch_tracking_key(credential_name: str = '', credential_vat: str = '') -> str:
+    """Return stable key for last-fetch tracking (prefer VAT when available)."""
+    vat = str(credential_vat or '').strip()
+    if vat:
+        return vat
+
+    name = str(credential_name or '').strip()
+    if not name:
+        return ''
+
+    try:
+        creds = load_credentials() or []
+        found = next((c for c in creds if str(c.get('name', '')).strip() == name), None)
+        if found:
+            found_vat = str(found.get('vat', '')).strip()
+            if found_vat:
+                return found_vat
+    except Exception:
+        pass
+
+    return name
+
+
 def set_last_fetch_date(credential_name: str, date_str: Optional[str] = None) -> bool:
     """
     Set the last fetch date for a credential in fiscal_meta.json.
@@ -3421,12 +3444,14 @@ def read_client_meta(base_dir=None):
     return None
 
 
-def write_client_meta(filename, uploaded_at_iso, base_dir=None):
-    """Write metadata (filename, uploaded_at iso) to meta file inside base_dir (or DATA_DIR)."""
+def write_client_meta(filename, uploaded_at_iso, base_dir=None, extra_meta=None):
+    """Write metadata for client_db inside base_dir (or DATA_DIR)."""
     meta = {
         'filename': filename,
         'uploaded_at': uploaded_at_iso
     }
+    if isinstance(extra_meta, dict) and extra_meta:
+        meta.update(extra_meta)
     meta_path = _client_meta_path(base_dir)
     try:
         os.makedirs(os.path.dirname(meta_path), exist_ok=True)
@@ -5929,11 +5954,10 @@ def api_save_receipt():
 @app.route('/upload_client_db', methods=['POST'])
 def upload_client_db():
     """
-    Accept multipart/form-data with field 'client_file' and save it into DATA_DIR
-    as client_db{.ext}. Existing client_db* files are moved to a single backup
-    (previous backups removed), and client_db.meta.json is written.
-    Returns JSON { success: bool, message: str, missing_columns: [...], detected_columns: [...],
-                   uploaded_at: str, total_rows: int, new_clients: int, existing_clients: int }
+    Accept multipart/form-data with field 'client_file' and save/update it in group DATA_DIR
+    as client_db{.ext}. Existing rows are merged by AFM (new upload updates same AFM,
+    unknown AFM rows are appended) and client_db.meta.json is updated.
+    Returns JSON with upload/merge stats.
     """
     # Permission check: only admins can upload client_db
     try:
@@ -5948,8 +5972,6 @@ def upload_client_db():
         return jsonify(success=False, message='Ο έλεγχος δικαιωμάτων απέτυχε.'), 403
 
     try:
-        os.makedirs(DATA_DIR, exist_ok=True)
-
         if 'client_file' not in request.files:
             return jsonify(success=False, message='Δεν βρέθηκε το πεδίο client_file στο αίτημα.'), 400
 
@@ -5957,162 +5979,185 @@ def upload_client_db():
         if not f or not getattr(f, 'filename', '').strip():
             return jsonify(success=False, message='Δεν επιλέχθηκε αρχείο.'), 400
 
-        filename = secure_filename(f.filename)
-        base, ext = os.path.splitext(filename)
+        uploaded_original_name = secure_filename(f.filename)
+        _, ext = os.path.splitext(uploaded_original_name)
         ext = ext.lower()
         if ext not in ALLOWED_CLIENT_EXT:
             return jsonify(success=False, message='Μη επιτρεπτή επέκταση. Χρήση .xlsx, .xls ή .csv'), 400
 
-        # --- Έλεγχος headers ---
-        try:
-            stream = f.stream
-            success, headers, err = _extract_headers_from_upload(stream, ext)
-            if not success:
-                return jsonify(success=False, message=err or 'Αποτυχία ανάγνωσης αρχείου για έλεγχο headers.'), 400
+        # Resolve target group base once.
+        target_base = get_group_base_dir()
+        os.makedirs(target_base, exist_ok=True)
 
-            headers_set = {str(h).strip() for h in headers}
-            missing = sorted(list(REQUIRED_CLIENT_COLUMNS - headers_set))
-            if missing:
-                return jsonify(success=False,
-                               message='Λείπουν υποχρεωτικές στήλες.',
-                               missing_columns=missing,
-                               detected_columns=sorted(list(headers_set))), 400
-        except Exception as e:
-            log.exception("Error while extracting headers from uploaded client_file")
-            return jsonify(success=False, message=f'Σφάλμα κατά τον έλεγχο των στηλών: {e}'), 500
-
-        # --- Ανάγνωση client_file για επεξεργασία πελατών ---
+        # Read upload once (header validation is done on DataFrame columns to reduce I/O).
         try:
-            log.info("[Client DB Upload] Reading file with extension: %s", ext)
             f.stream.seek(0)
             if ext in ['.xls', '.xlsx']:
-                df = pd.read_excel(f.stream, dtype=str)
+                df_upload = pd.read_excel(f.stream, dtype=str)
             else:
-                df = pd.read_csv(f.stream, dtype=str)
-            df.fillna('', inplace=True)
-            log.info("[Client DB Upload] File read successfully: %d rows, %d columns", len(df), len(df.columns))
+                df_upload = pd.read_csv(f.stream, dtype=str)
+            df_upload.fillna('', inplace=True)
         except Exception as e:
-            log.exception("[Client DB Upload] Failed to read uploaded client_file")
+            log.exception('[Client DB Upload] Failed to read uploaded client_file')
             return jsonify(success=False, message=f'Σφάλμα κατά την ανάγνωση του αρχείου: {e}'), 500
 
-        total_rows = len(df)
-        log.info("[Client DB Upload] Total rows in file: %d", total_rows)
-        existing_clients_set = get_existing_client_ids()
-        new_clients_set = set()
-        already_existing_set = set()
+        headers_set = {str(h).strip() for h in df_upload.columns}
+        missing = sorted(list(REQUIRED_CLIENT_COLUMNS - headers_set))
+        if missing:
+            return jsonify(
+                success=False,
+                message='Λείπουν υποχρεωτικές στήλες.',
+                missing_columns=missing,
+                detected_columns=sorted(list(headers_set))
+            ), 400
 
-        for afm in df.get("ΑΦΜ", []):
-            afm_str = str(afm).strip()
-            if afm_str:
-                if afm_str in existing_clients_set:
-                    already_existing_set.add(afm_str)
-                else:
-                    new_clients_set.add(afm_str)
-        
-        log.info("[Client DB Upload] Processing complete: new=%d, existing=%d, total=%d", 
-                 len(new_clients_set), len(already_existing_set), total_rows)
+        # Determine existing client_db file (if any).
+        existing_path = None
+        existing_ext = None
+        for existing in os.listdir(target_base):
+            if not existing.startswith('client_db'):
+                continue
+            ext_candidate = os.path.splitext(existing)[1].lower()
+            if ext_candidate in ALLOWED_CLIENT_EXT and '.bak.' not in existing and not existing.endswith('.bak'):
+                existing_path = os.path.join(target_base, existing)
+                existing_ext = ext_candidate
+                break
 
-        # --- Backup: keep only one backup ---
-        # save into the user's group folder when possible
-        try:
-            from flask_login import current_user
-            target_base = DATA_DIR
-            requested_group = (request.form.get('group') or '').strip()
-            if getattr(current_user, 'is_authenticated', False):
-                user_groups = getattr(current_user, 'groups', [])
-                if requested_group:
-                    grp = None
-                    for g in user_groups:
-                        if g.name == requested_group:
-                            grp = g
-                            break
-                    if not grp:
-                        return jsonify(success=False, message='Δεν έχετε πρόσβαση στην επιλεγμένη ομάδα.'), 403
-                    target_base = os.path.join(BASE_DIR, 'data', grp.data_folder or '')
-                else:
-                    # Try to use active_group from session first
-                    active_group_name = session.get('active_group')
-                    if active_group_name:
-                        for g in user_groups:
-                            if g.name == active_group_name:
-                                target_base = os.path.join(BASE_DIR, 'data', g.data_folder or '')
-                                break
-                    else:
-                        # Fallback: if only 1 group, use it; otherwise require explicit group param
-                        if len(user_groups) == 1:
-                            target_base = os.path.join(BASE_DIR, 'data', user_groups[0].data_folder or '')
-                        else:
-                            return jsonify(success=False, message='Έχετε πολλές ομάδες. Συμπληρώστε το πεδίο group στο αίτημα.'), 400
-            os.makedirs(target_base, exist_ok=True)
+        # Keep stable naming convention client_db{.ext}; if a client_db already exists, preserve its extension.
+        final_ext = existing_ext or ext
+        dest_name = f'client_db{final_ext}'
+        dest_path = os.path.join(target_base, dest_name)
 
-            dest_name = f'client_db{ext}'
-            dest_path = os.path.join(target_base, dest_name)
+        # Merge strategy by AFM: upload updates existing AFM, new AFM appended.
+        merge_source_rows = len(df_upload)
+        merged_rows = merge_source_rows
+        updated_clients = 0
+        new_clients = 0
+        if 'ΑΦΜ' in df_upload.columns:
+            upload_afm = df_upload['ΑΦΜ'].astype(str).str.strip()
+            upload_unique_afm = set(a for a in upload_afm if a)
+        else:
+            upload_unique_afm = set()
 
-            # 1) remove any previous backups in target_base
-            for existing in os.listdir(target_base):
-                if not existing.startswith('client_db'):
-                    continue
-                if '.bak.' in existing or existing.endswith('.bak'):
-                    try:
-                        os.remove(os.path.join(target_base, existing))
-                        log.info("Removed old client_db backup: %s", existing)
-                    except Exception:
-                        log.exception("Failed to remove old backup %s (continuing)", existing)
-
-            # 2) move current client_db.* (if any) to a new single backup (timestamped)
-            for existing in os.listdir(target_base):
-                if existing.startswith('client_db'):
-                    existing_ext = os.path.splitext(existing)[1].lower()
-                    if existing_ext in ALLOWED_CLIENT_EXT:
-                        existing_path = os.path.join(target_base, existing)
-                        ts = _dt.utcnow().strftime('%Y%m%dT%H%M%SZ')
-                        backup_name = f"{existing}.bak.{ts}"
-                        backup_path = os.path.join(target_base, backup_name)
-                        try:
-                            os.rename(existing_path, backup_path)
-                            log.info("Backed up previous client_db: %s -> %s", existing, backup_name)
-                        except Exception:
-                            log.exception("Failed to backup previous client_db %s (continuing)", existing)
-
-            # --- Save uploaded file to destination path ---
+        if existing_path and os.path.exists(existing_path):
             try:
-                f.stream.seek(0)
-                f.save(dest_path)
+                if existing_ext in ['.xls', '.xlsx']:
+                    df_existing = pd.read_excel(existing_path, dtype=str)
+                else:
+                    df_existing = pd.read_csv(existing_path, dtype=str)
+                df_existing.fillna('', inplace=True)
+
+                # Align schemas (keep all columns from both sources).
+                all_columns = list(dict.fromkeys([*df_existing.columns.tolist(), *df_upload.columns.tolist()]))
+                df_existing = df_existing.reindex(columns=all_columns, fill_value='')
+                df_upload = df_upload.reindex(columns=all_columns, fill_value='')
+
+                if 'ΑΦΜ' in df_existing.columns and 'ΑΦΜ' in df_upload.columns:
+                    existing_afm = df_existing['ΑΦΜ'].astype(str).str.strip()
+                    existing_afm_set = set(a for a in existing_afm if a)
+
+                    updated_clients = len(upload_unique_afm & existing_afm_set)
+                    new_clients = len(upload_unique_afm - existing_afm_set)
+
+                    # Keep existing rows only for AFMs not re-uploaded, then append full uploaded set.
+                    keep_mask = ~existing_afm.isin(upload_unique_afm)
+                    df_merged = pd.concat([df_existing.loc[keep_mask], df_upload], ignore_index=True)
+                else:
+                    # Missing AFM in one of datasets: safe append fallback.
+                    df_merged = pd.concat([df_existing, df_upload], ignore_index=True)
+                    new_clients = len(upload_unique_afm)
+
+                df_merged.fillna('', inplace=True)
+                merged_rows = len(df_merged)
             except Exception:
-                log.exception("Failed to save uploaded client_db to %s", dest_path)
-                return jsonify(success=False, message='Σφάλμα κατά την αποθήκευση του αρχείου.'), 500
+                log.exception('[Client DB Upload] Failed reading existing client_db; fallback to uploaded file only')
+                df_merged = df_upload.copy()
+                new_clients = len(upload_unique_afm)
+                updated_clients = 0
+                merged_rows = len(df_merged)
+        else:
+            df_merged = df_upload.copy()
+            new_clients = len(upload_unique_afm)
+            updated_clients = 0
 
-        except Exception:
-            log.exception("Failed while rotating client_db backups (continuing)")
+        # Rotate backups only after merge is ready.
+        for existing in os.listdir(target_base):
+            if not existing.startswith('client_db'):
+                continue
+            if '.bak.' in existing or existing.endswith('.bak'):
+                try:
+                    os.remove(os.path.join(target_base, existing))
+                except Exception:
+                    log.exception('Failed to remove old backup %s (continuing)', existing)
 
-        # --- Meta info ---
-        uploaded_at_iso = _dt.utcnow().replace(microsecond=0).isoformat() + 'Z'
-        try:
-            log.info("[Client DB Upload] Writing metadata to base_dir: %s", target_base)
+        if os.path.exists(dest_path):
+            ts = _dt.utcnow().strftime('%Y%m%dT%H%M%SZ')
+            backup_name = f"{dest_name}.bak.{ts}"
             try:
-                write_client_meta(filename, uploaded_at_iso, base_dir=target_base)
-                log.info("[Client DB Upload] Metadata written successfully")
-            except Exception as meta_err:
-                log.error("[Client DB Upload] Failed to write metadata to target_base, trying fallback: %s", meta_err)
-                # fallback to global meta write
-                write_client_meta(filename, uploaded_at_iso)
-                log.info("[Client DB Upload] Metadata written to fallback location")
+                os.rename(dest_path, os.path.join(target_base, backup_name))
+            except Exception:
+                log.exception('Failed to backup previous client_db %s (continuing)', dest_name)
+
+        # If existing file had different extension, archive it too (single active canonical file remains).
+        if existing_path and os.path.exists(existing_path) and os.path.abspath(existing_path) != os.path.abspath(dest_path):
+            ts = _dt.utcnow().strftime('%Y%m%dT%H%M%SZ')
+            try:
+                os.rename(existing_path, os.path.join(target_base, f"{os.path.basename(existing_path)}.bak.{ts}"))
+            except Exception:
+                log.exception('Failed to archive previous client_db variant %s', existing_path)
+
+        # Save merged dataset.
+        try:
+            if final_ext in ['.xls', '.xlsx']:
+                if final_ext == '.xlsx':
+                    df_merged.to_excel(dest_path, index=False, engine='openpyxl')
+                else:
+                    # Try legacy .xls writer; fallback to .xlsx if not available.
+                    try:
+                        df_merged.to_excel(dest_path, index=False)
+                    except Exception:
+                        log.warning('Legacy .xls writer unavailable, falling back to .xlsx')
+                        final_ext = '.xlsx'
+                        dest_name = f'client_db{final_ext}'
+                        dest_path = os.path.join(target_base, dest_name)
+                        df_merged.to_excel(dest_path, index=False, engine='openpyxl')
+            else:
+                df_merged.to_csv(dest_path, index=False, encoding='utf-8-sig')
         except Exception:
-            log.exception("[Client DB Upload] Failed to write client_db metadata (continuing anyway)")
+            log.exception('Failed to save merged client_db to %s', dest_path)
+            return jsonify(success=False, message='Σφάλμα κατά την αποθήκευση του ενημερωμένου αρχείου.'), 500
+
+        uploaded_at_iso = _dt.utcnow().replace(microsecond=0).isoformat() + 'Z'
+        meta_extra = {
+            'original_filename': uploaded_original_name,
+            'storage_filename': dest_name,
+            'total_rows': int(merged_rows),
+            'source_rows': int(merge_source_rows),
+            'new_clients': int(new_clients),
+            'existing_clients': int(updated_clients),
+            'merge_mode': 'upsert_by_afm'
+        }
+        try:
+            # Keep canonical naming in metadata too.
+            write_client_meta(dest_name, uploaded_at_iso, base_dir=target_base, extra_meta=meta_extra)
+        except Exception:
+            log.exception('[Client DB Upload] Failed to write client_db metadata (continuing anyway)')
 
         return jsonify(
             success=True,
-            message=f'Αποθηκεύτηκε: {dest_name}',
-            filename=filename,
+            message=f'Αποθηκεύτηκε/ενημερώθηκε: {dest_name}',
+            filename=dest_name,
+            original_filename=uploaded_original_name,
             uploaded_at=uploaded_at_iso,
             detected_columns=sorted(list(headers_set)),
-            total_rows=total_rows,
-            new_clients=len(new_clients_set),
-            existing_clients=len(already_existing_set)
+            total_rows=int(merged_rows),
+            source_rows=int(merge_source_rows),
+            new_clients=int(new_clients),
+            existing_clients=int(updated_clients)
         ), 200
 
     except Exception:
-        log.exception("Unhandled exception in upload_client_db")
+        log.exception('Unhandled exception in upload_client_db')
         return jsonify(success=False, message='Εσωτερικό σφάλμα server.'), 500
 
 
@@ -6255,7 +6300,8 @@ def _upload_chart_of_accounts_impl(category='G'):
             return jsonify(ok=False, error='Εσωτερικό σφάλμα: Μη έγκυρο πλήθος λογαριασμών.'), 500
             
         meta = {
-            'filename': filename,
+            'filename': dest_name,
+            'original_filename': filename,
             'uploaded_at': uploaded_at,
             'account_count': account_count,
             'category': category,
@@ -6276,7 +6322,8 @@ def _upload_chart_of_accounts_impl(category='G'):
         return jsonify(
             ok=True,
             message=f'Το λογιστικό σχέδιο {category_label} αποθηκεύτηκε επιτυχώς (κοινόχρηστο για όλη την ομάδα)',
-            filename=filename,
+            filename=dest_name,
+            original_filename=filename,
             uploaded_at=uploaded_at,
             account_count=account_count,
             category=category,
@@ -6653,10 +6700,15 @@ def api_last_fetch_date():
     """
     try:
         credential_name = (request.args.get("credential") or "").strip()
-        if not credential_name:
+        credential_vat = (request.args.get("vat") or "").strip()
+        if not credential_name and not credential_vat:
             return jsonify({"last_fetch_date": None}), 400
-        
-        last_date = get_last_fetch_date(credential_name)
+
+        fetch_key = _get_fetch_tracking_key(credential_name, credential_vat)
+        last_date = get_last_fetch_date(fetch_key) if fetch_key else None
+        if not last_date and credential_name and fetch_key != credential_name:
+            # Backward compatibility: older installs may have written by credential name.
+            last_date = get_last_fetch_date(credential_name)
         
         # Format for display if available
         if last_date:
@@ -6703,65 +6755,54 @@ def client_db_info():
     { exists: bool, filename: str|null, uploaded_at: str|null, total_rows: int, new_rows: int, updated_rows: int }
     """
     try:
-        # prefer per-user group meta when authenticated
+        # Always resolve against the active group first to avoid cross-group metadata mismatches.
+        target_base = get_group_base_dir()
+        requested_group = (request.args.get('group') or '').strip()
         try:
             from flask_login import current_user
-            target_base = DATA_DIR
-            requested_group = (request.args.get('group') or '').strip()
-            if getattr(current_user, 'is_authenticated', False):
+            if requested_group and getattr(current_user, 'is_authenticated', False):
                 user_groups = getattr(current_user, 'groups', [])
-                if requested_group:
-                    grp = None
-                    for g in user_groups:
-                        if g.name == requested_group:
-                            grp = g
-                            break
-                    if not grp:
-                        return jsonify({'ok': False, 'error': 'Δεν έχετε πρόσβαση στην επιλεγμένη ομάδα.'}), 403
-                    target_base = os.path.join(BASE_DIR, 'data', grp.data_folder or '')
-                else:
-                    if len(user_groups) == 1:
-                        target_base = os.path.join(BASE_DIR, 'data', user_groups[0].data_folder or '')
-            meta = read_client_meta(base_dir=target_base)
+                grp = next((g for g in user_groups if g.name == requested_group), None)
+                if not grp:
+                    return jsonify({'ok': False, 'error': 'Δεν έχετε πρόσβαση στην επιλεγμένη ομάδα.'}), 403
+                target_base = os.path.join(BASE_DIR, 'data', grp.data_folder or '')
         except Exception:
-            meta = read_client_meta()
+            pass
+
+        meta = read_client_meta(base_dir=target_base)
         counts = {'total_rows': 0, 'new_rows': 0, 'updated_rows': 0}
 
         if meta:
-            # αν υπάρχει client_db, διαβάζουμε για μέτρηση
-            p = os.path.join(target_base, f"client_db{os.path.splitext(meta.get('filename',''))[1]}")
-            if os.path.exists(p):
-                try:
-                    ext = os.path.splitext(p)[1].lower()
-                    if ext in ['.xls', '.xlsx']:
-                        df = pd.read_excel(p, dtype=str)
-                    else:
-                        df = pd.read_csv(p, dtype=str)
-                    df.fillna('', inplace=True)
-                    total_rows = len(df)
-                    existing_clients_set = set(get_existing_client_ids())
-                    new_rows = updated_rows = 0
-                    for idx, row in df.iterrows():
-                        client_id = str(row.get("ΑΦΜ", "")).strip()
-                        if not client_id:
-                            continue
-                        if client_id in existing_clients_set:
-                            updated_rows += 1
+            # Prefer precomputed counts from metadata (upload path stores these for low-resource environments).
+            if any(k in meta for k in ('total_rows', 'new_clients', 'existing_clients')):
+                counts.update({
+                    'total_rows': int(meta.get('total_rows') or 0),
+                    'new_rows': int(meta.get('new_clients') or 0),
+                    'updated_rows': int(meta.get('existing_clients') or 0),
+                })
+            else:
+                # Fallback only for old metadata versions.
+                p = os.path.join(target_base, str(meta.get('storage_filename') or meta.get('filename') or 'client_db.xlsx'))
+                if os.path.exists(p):
+                    try:
+                        ext = os.path.splitext(p)[1].lower()
+                        if ext in ['.xls', '.xlsx']:
+                            df = pd.read_excel(p, dtype=str)
                         else:
-                            new_rows += 1
-                            existing_clients_set.add(client_id)
-                    counts.update({'total_rows': total_rows, 'new_rows': new_rows, 'updated_rows': updated_rows})
-                except Exception:
-                    log.exception("Failed to count client_db rows")
+                            df = pd.read_csv(p, dtype=str)
+                        df.fillna('', inplace=True)
+                        counts['total_rows'] = len(df)
+                    except Exception:
+                        log.exception("Failed to count client_db rows")
 
-            return jsonify(exists=True, filename=meta.get('filename'),
+            return jsonify(exists=True, filename=meta.get('storage_filename') or meta.get('filename'),
                            uploaded_at=meta.get('uploaded_at'),
                            **counts), 200
 
         # fallback: if any client_db.* exists but no meta file
-        for existing in os.listdir(get_group_base_dir()):
+        for existing in os.listdir(target_base):
             if existing.startswith('client_db') and os.path.splitext(existing)[1].lower() in ALLOWED_CLIENT_EXT:
-                p = os.path.join(get_group_base_dir(), existing)
+                p = os.path.join(target_base, existing)
                 try:
                     mtime = _dt.utcfromtimestamp(os.path.getmtime(p)).replace(microsecond=0).isoformat() + 'Z'
                     counts.update({'total_rows': 0, 'new_rows': 0, 'updated_rows': 0})
@@ -7111,9 +7152,10 @@ def fetch():
                 if append_summary_to_customer_file(s, vat):
                     added_summaries += 1
 
-            # Track last fetch date for this credential
-            if selected:
-                set_last_fetch_date(selected)
+            # Track last fetch date for this selected client (prefer VAT key).
+            fetch_key = _get_fetch_tracking_key(selected, vat)
+            if fetch_key:
+                set_last_fetch_date(fetch_key)
             
             # Log fetch operation as structured activity (so admin UI shows details)
             try:
@@ -11372,4 +11414,3 @@ if __name__ == "__main__":
     port = int(os.getenv("PORT", "5001"))
     debug_flag = True
     app.run(host="0.0.0.0", port=port, debug=debug_flag, use_reloader=True)
-

--- a/firebase_config.py
+++ b/firebase_config.py
@@ -758,13 +758,32 @@ def firebase_pull_group_to_local(group_name: str, local_data_root: str = None) -
         
         def _get_file_name_with_extension(key_name):
             """
-            Convert key name to proper file name with extension.
-            E.g., 'credentials_settings_json' -> 'credentials_settings.json'
-                  '12345679_2024_invoices_xlsx' -> '12345679_2024_invoices.xlsx'
+            Convert Firebase key names back to local file names.
+            Handles both unsanitized keys (foo.xlsx.meta_json) and sanitized ones
+            produced by RTDB key rules (foo_xlsx_meta_json).
             """
             key_str = str(key_name).lstrip('/')
-            
-            # Map of suffixes to extensions
+
+            # Handle sanitized metadata keys first (critical for CoA/client_db metadata).
+            special_suffixes = {
+                '_xlsx_meta_json': '.xlsx.meta.json',
+                '_xls_meta_json': '.xls.meta.json',
+                '_csv_meta_json': '.csv.meta.json',
+            }
+            for suffix, ext in special_suffixes.items():
+                if key_str.endswith(suffix):
+                    return f"{key_str[:-len(suffix)]}{ext}"
+
+            # Also handle unsanitized metadata keys.
+            unsanitized_suffixes = {
+                '.xlsx.meta_json': '.xlsx.meta.json',
+                '.xls.meta_json': '.xls.meta.json',
+                '.csv.meta_json': '.csv.meta.json',
+            }
+            for suffix, ext in unsanitized_suffixes.items():
+                if key_str.endswith(suffix):
+                    return f"{key_str[:-len(suffix)]}{ext}"
+
             extension_map = {
                 '_json': '.json',
                 '_xlsx': '.xlsx',
@@ -775,15 +794,11 @@ def firebase_pull_group_to_local(group_name: str, local_data_root: str = None) -
                 '_xml': '.xml',
                 '_log': '.log',
             }
-            
-            # Check for known extensions at the end
+
             for suffix, ext in extension_map.items():
                 if key_str.endswith(suffix):
-                    # Replace the suffix with the extension
-                    base_name = key_str[:-len(suffix)]
-                    return f"{base_name}{ext}"
-            
-            # If no extension found, return as-is
+                    return f"{key_str[:-len(suffix)]}{ext}"
+
             return key_str
         
         # compute total files to process for progress estimation

--- a/templates/credentials_list.html
+++ b/templates/credentials_list.html
@@ -186,7 +186,7 @@
           </thead>
           <tbody>
             {% for c in credentials %}
-            <tr id="cred-row-{{ c.name | replace(' ', '_') }}" class="credential-row hover:bg-sky-50 transition-colors border-b" data-customer-vat="{{ c.vat }}">
+            <tr id="cred-row-{{ c.name | replace(' ', '_') }}" class="credential-row hover:bg-sky-50 transition-colors border-b" data-customer-vat="{{ c.vat }}" data-customer-name="{{ c.name|e }}">
               <td class="px-4 py-3 text-center align-middle">
                 <input type="radio" name="active_name" value="{{ c.name }}" {% if active_credential==c.name %}checked{% endif %}>
               </td>
@@ -1608,7 +1608,8 @@ function initializeSettingsUi(){
   // special rules
   // εγγυοδοσια: only 0% enabled
   // αποδειξακια: only 0% enabled, others disabled + tooltip about "ανάλυση ΦΠΑ σύντομα διαθέσιμη"
-  const specialTooltip = 'Η ανάλυση ΦΠΑ στα αποδειξάκια θα είναι σύντομα διαθέσιμη.';
+  const receiptTooltip = 'Η ανάλυση ΦΠΑ στα αποδειξάκια θα είναι σύντομα διαθέσιμη.';
+  const guaranteeTooltip = 'Η εγγυοδοσία δεν επιβαρύνεται με ΦΠΑ.';
   document.querySelectorAll('.settings-card').forEach(card=>{
     const cat = (card.dataset.cat||'').toString();
     if(cat === 'εγγυοδοσια' || cat === 'αποδειξακια'){
@@ -1617,23 +1618,24 @@ function initializeSettingsUi(){
         const parts = name.split('_');
         const rawVat = parts[parts.length - 1];
         const vat = String(rawVat).replace('%', '').trim(); // -> "0" αντί "0%"
+        const tooltip = (cat === 'εγγυοδοσια') ? guaranteeTooltip : receiptTooltip;
         if (vat !== '0') {
-        inp.classList.add('input-disabled');
-        inp.setAttribute('disabled','disabled');
-          // attach tooltip when category is αποδειξακια
-          if(cat === 'αποδειξακια'){
-            const wrap = inp.parentElement;
-            if(wrap){
-              wrap.classList.add('setting-tooltip');
-              wrap.setAttribute('data-tooltip', specialTooltip);
-            } else {
-              inp.setAttribute('title', specialTooltip);
-            }
+          inp.classList.add('input-disabled');
+          inp.setAttribute('disabled','disabled');
+          inp.setAttribute('title', tooltip);
+          const wrap = inp.parentElement;
+          if(wrap){
+            wrap.classList.add('setting-tooltip');
+            wrap.setAttribute('data-tooltip', tooltip);
           }
         } else {
           inp.classList.remove('input-disabled');
           inp.removeAttribute('disabled');
-          if(inp.parentElement) { inp.parentElement.removeAttribute('data-tooltip'); }
+          inp.removeAttribute('title');
+          if(inp.parentElement) {
+            inp.parentElement.removeAttribute('data-tooltip');
+            inp.parentElement.classList.remove('setting-tooltip');
+          }
         }
       });
     }
@@ -2216,26 +2218,31 @@ function populateBackupCustomerList() {
   const list = document.getElementById('backup-customer-list');
   if (!list) return;
   
-  // Extract customer VATs from the page (from credentials list or similar)
+  // Extract customer entries from credentials table.
   const customerList = [];
+  const seenVat = new Set();
   document.querySelectorAll('[data-customer-vat]').forEach(el => {
-    const vat = el.getAttribute('data-customer-vat');
-    if (vat && !customerList.includes(vat)) {
-      customerList.push(vat);
-    }
+    const vat = (el.getAttribute('data-customer-vat') || '').trim();
+    const name = (el.getAttribute('data-customer-name') || '').trim();
+    if (!vat || seenVat.has(vat)) return;
+    seenVat.add(vat);
+    customerList.push({ vat, name });
   });
-  
+
   if (!customerList.length) {
     list.innerHTML = '<p class="text-xs text-gray-500">Δεν βρέθηκαν πελάτες.</p>';
     return;
   }
-  
-  list.innerHTML = customerList.map(vat => `
-    <label class="flex items-center gap-2">
-      <input type="checkbox" name="backup-customer-select" value="${escapeHtml(vat)}" />
-      <span class="text-sm">${escapeHtml(vat)}</span>
-    </label>
-  `).join('');
+
+  list.innerHTML = customerList.map(({ vat, name }) => {
+    const label = name ? `${name} (${vat})` : vat;
+    return `
+      <label class="flex items-center gap-2">
+        <input type="checkbox" name="backup-customer-select" value="${escapeHtml(vat)}" />
+        <span class="text-sm">${escapeHtml(label)}</span>
+      </label>
+    `;
+  }).join('');
 }
 
 function selectAllCustomers() {

--- a/templates/fetch.html
+++ b/templates/fetch.html
@@ -50,7 +50,7 @@
             {% for c in credentials %}
               {%- set selected_val = (request.form.get('use_credential') == c.name) or (not request.form.get('use_credential') and active_credential == c.name) -%}
               {%- set label = c.name ~ (c.vat and (' (' ~ c.vat ~ ')') or '') -%}
-              <option value="{{ c.name }}" {% if selected_val %}selected{% endif %}>{{ label }}</option>
+              <option value="{{ c.name }}" data-vat="{{ c.vat or "" }}" {% if selected_val %}selected{% endif %}>{{ label }}</option>
             {% endfor %}
           </select>
         </div>
@@ -208,7 +208,11 @@ document.addEventListener("DOMContentLoaded", function() {
       return;
     }
     try {
-      const res = await fetch('/api/last_fetch_date?credential=' + encodeURIComponent(credentialName));
+      const selectedOption = credentialSelect.options[credentialSelect.selectedIndex];
+      const vat = (selectedOption && selectedOption.dataset && selectedOption.dataset.vat) ? selectedOption.dataset.vat.trim() : '';
+      const query = new URLSearchParams({ credential: credentialName });
+      if (vat) query.set('vat', vat);
+      const res = await fetch('/api/last_fetch_date?' + query.toString());
       if (res.ok) {
         const data = await res.json();
         if (data.last_fetch_date) {

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -195,7 +195,12 @@
   }
 
   function categoriesForVat(vatKey, allTags){
-    return (allTags || []).filter(cat => allowedForVat(cat, vatKey));
+    return (allTags || []).filter(cat => {
+      const key = String(cat || '').trim();
+      // Εγγυοδοσία: επιτρέπεται μόνο στο 0%.
+      if(key === 'εγγυοδοσια' && vatKey !== '0%') return false;
+      return allowedForVat(key, vatKey);
+    });
   }
 
   function ensureOption(select, value, vatKey){


### PR DESCRIPTION
### Motivation
- Ensure the UI enforces the business rule that εγγυοδοσία (guarantee) is only charged at 0% and communicates this to users via tooltip. 
- Make backup customer selection more user-friendly by showing `Όνομα (ΑΦΜ)` while keeping the checkbox value as the VAT. 
- Improve client DB upload robustness by merging uploads by AFM, persisting richer metadata and making client_db info queries group-aware. 

### Description
- UI: `templates/credentials_list.html` — disabled non-0% VAT inputs for `εγγυοδοσια` with a hover/title tooltip `Η εγγυοδοσία δεν επιβαρύνεται με ΦΠΑ.`, kept 0% editable, and added `data-customer-name` to credential rows so backup list can show `Όνομα (ΑΦΜ)` while the checkbox value remains the VAT. 
- UI: `templates/profiles.html` — updated `categoriesForVat` to exclude `εγγυοδοσια` from any VAT dropdown except `0%` so repeat-profile creation shows εγγυοδοσία only in the 0% select. 
- UI: `templates/fetch.html` — include selected credential VAT in `/api/last_fetch_date` requests to prefer VAT-based last-fetch tracking. 
- Server: `app.py` — added `_get_fetch_tracking_key` to prefer VAT when tracking last-fetch dates and changed `api_last_fetch_date` and fetch tracking to use this key for backward-compatible behavior. 
- Server: `app.py` — enhanced client DB upload endpoint (`/upload_client_db`) to: merge upload with existing `client_db` by AFM (upsert), preserve/choose canonical `client_db{ext}` filename, rotate backups, and write richer metadata fields (`original_filename`, `storage_filename`, `total_rows`, `source_rows`, `new_clients`, `existing_clients`, `merge_mode`). Response now returns canonical `filename` and `original_filename` plus counts. 
- Server: `app.py` — updated `client_db_info` to prefer group-scoped metadata, read precomputed counts from metadata when available, and return consistent fields. 
- Misc: `app.py` — CoA upload metadata now records canonical storage name and `original_filename` in metadata and response. 
- Tooling: `firebase_config.py` — improved key->filename mapping to better handle sanitized metadata keys (helps pulling metadata files with extensions). 

### Testing
- Compiled the modified application module successfully with `python3 -m py_compile app.py`. (success) 
- Performed static checks and grep searches to validate injected JS snippets and data-attribute usage across `templates/credentials_list.html`, `templates/profiles.html`, and `templates/fetch.html`. (ok) 
- Attempted a headless browser screenshot of the running app to validate UI, but the local server endpoint was not responding (Playwright `ERR_EMPTY_RESPONSE`), so full end-to-end UI verification on a running server was not completed. (not executed)
- Manual code inspection of server-side merge logic and metadata writing was performed; no automated unit tests were present or run. (inspection)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b3f3c79e4832898ae490a7467c91f)