### PR TITLE
Support chat: Discord->UI sync, typing/read receipts and attachments

### DIFF
--- a/app.py
+++ b/app.py
@@ -9974,6 +9974,12 @@ def _support_store_path() -> str:
     return group_path("support_tickets.json")
 
 
+def _support_upload_dir() -> str:
+    p = group_path("support_uploads")
+    os.makedirs(p, exist_ok=True)
+    return p
+
+
 def _support_load() -> Dict[str, Any]:
     p = _support_store_path()
     data = _safe_json_read(p, default={})
@@ -9982,6 +9988,7 @@ def _support_load() -> Dict[str, Any]:
     data.setdefault("tickets", [])
     data.setdefault("messages", [])
     data.setdefault("next_id", 1)
+    data.setdefault("next_message_id", 1)
     return data
 
 
@@ -10013,6 +10020,43 @@ def _support_close_ticket_record(ticket: Dict[str, Any], closed_by: str = "user"
     ticket["updated_at"] = _support_now_iso()
 
 
+def _support_next_message_id(data: Dict[str, Any]) -> int:
+    mid = int(data.get("next_message_id") or 1)
+    data["next_message_id"] = mid + 1
+    return mid
+
+
+def _support_store_uploaded_files(files: List[Any]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    if not files:
+        return out
+    root = _support_upload_dir()
+    for f in files:
+        if not getattr(f, "filename", None):
+            continue
+        original = secure_filename(f.filename or "")[:120]
+        if not original:
+            continue
+        ext = os.path.splitext(original)[1][:10]
+        token = secrets.token_hex(12)
+        disk_name = f"{token}{ext}"
+        disk_path = os.path.join(root, disk_name)
+        f.save(disk_path)
+        try:
+            size = int(os.path.getsize(disk_path) or 0)
+        except Exception:
+            size = 0
+        out.append({
+            "id": token,
+            "name": original,
+            "size": size,
+            "mime": str(getattr(f, "mimetype", "") or "application/octet-stream"),
+            "path": disk_name,
+            "url": f"/api/support/attachment/{token}",
+        })
+    return out
+
+
 def _support_discord_archive_thread(thread_id: str) -> bool:
     token = (os.getenv("DISCORD_BOT_TOKEN") or os.getenv("DISCORD_KEY") or "").strip()
     if not token or not thread_id:
@@ -10037,20 +10081,79 @@ def _support_discord_archive_thread(thread_id: str) -> bool:
         return False
 
 
-def _support_discord_create_thread(ticket: Dict[str, Any], first_message: str) -> Optional[str]:
+def _support_discord_headers() -> Optional[Dict[str, str]]:
     token = (os.getenv("DISCORD_BOT_TOKEN") or os.getenv("DISCORD_KEY") or "").strip()
-    channel_id = (
+    if not token:
+        return None
+    return {
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+    }
+
+
+def _support_discord_channel_id() -> str:
+    return (
         os.getenv("DISCORD_SUPPORT_CHANNEL_ID")
         or os.getenv("DISCORD_CHANNEL_ID")
         or "1471125053524414536"
     ).strip()
-    if not token or not channel_id:
+
+
+def _support_discord_send_message(channel_id: str, content: str, headers: Dict[str, str], attachments: Optional[List[Dict[str, Any]]] = None) -> bool:
+    if not channel_id:
+        return False
+    content = (content or "")[:1800]
+    files = []
+    handles = []
+    try:
+        if attachments:
+            payload = {"content": content}
+            for i, a in enumerate(attachments[:5]):
+                rel = str(a.get("path") or "")
+                if not rel:
+                    continue
+                abs_path = os.path.join(_support_upload_dir(), rel)
+                if not os.path.exists(abs_path):
+                    continue
+                h = open(abs_path, "rb")
+                handles.append(h)
+                files.append((f"files[{len(files)}]", (a.get("name") or f"file-{i}", h, a.get("mime") or "application/octet-stream")))
+            post_headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
+            r = requests.post(
+                f"https://discord.com/api/v10/channels/{channel_id}/messages",
+                headers=post_headers,
+                data={"payload_json": json.dumps(payload)},
+                files=files or None,
+                timeout=20,
+            )
+        else:
+            r = requests.post(
+                f"https://discord.com/api/v10/channels/{channel_id}/messages",
+                headers=headers,
+                json={"content": content},
+                timeout=12,
+            )
+        if not r.ok:
+            current_app.logger.warning("Discord send message failed: %s %s", r.status_code, r.text[:300])
+            return False
+        return True
+    except Exception:
+        current_app.logger.warning("Discord send message failed", exc_info=True)
+        return False
+    finally:
+        for h in handles:
+            try:
+                h.close()
+            except Exception:
+                pass
+
+
+def _support_discord_create_thread(ticket: Dict[str, Any], first_message: str, attachments: Optional[List[Dict[str, Any]]] = None) -> Optional[str]:
+    headers = _support_discord_headers()
+    channel_id = _support_discord_channel_id()
+    if not headers or not channel_id:
         return None
 
-    headers = {
-        "Authorization": f"Bot {token}",
-        "Content-Type": "application/json",
-    }
     try:
         thread_name = f"ticket-{ticket['id']}-{_support_slug(ticket.get('display_name') or ticket.get('username') or 'user')}"
         th = requests.post(
@@ -10101,26 +10204,87 @@ def _support_discord_create_thread(ticket: Dict[str, Any], first_message: str) -
             f"Group: {ticket.get('group_name') or '-'}\n"
             f"Message:\n{first_message}"
         )
-        requests.post(
-            f"https://discord.com/api/v10/channels/{thread_id}/messages",
-            headers=headers,
-            json={"content": content[:1800]},
-            timeout=12,
-        )
+        if not _support_discord_send_message(str(thread_id), content, headers, attachments=attachments):
+            return None
         return str(thread_id)
     except Exception:
         current_app.logger.warning("Discord thread integration failed", exc_info=True)
         return None
 
 
+def _support_discord_deliver_message(ticket: Dict[str, Any], message: str, attachments: Optional[List[Dict[str, Any]]] = None) -> Tuple[bool, Optional[str]]:
+    headers = _support_discord_headers()
+    channel_id = _support_discord_channel_id()
+    if not headers or not channel_id:
+        return False, None
+
+    thread_id = str(ticket.get("discord_thread_id") or "").strip()
+    if not thread_id:
+        thread_id = _support_discord_create_thread(ticket, message, attachments=attachments) or ""
+        if thread_id:
+            ticket["discord_thread_id"] = thread_id
+            return True, thread_id
+
+        fallback = (
+            f"[Ticket #{ticket.get('id')}] από {ticket.get('display_name') or ticket.get('username') or 'user'}\n"
+            f"VAT: {ticket.get('vat') or '-'}\n"
+            f"Group: {ticket.get('group_name') or '-'}\n"
+            f"{message}"
+        )
+        return _support_discord_send_message(channel_id, fallback, headers, attachments=attachments), None
+
+    content = (
+        f"[Ticket #{ticket.get('id')}] {ticket.get('display_name') or ticket.get('username') or 'user'}\n"
+        f"{message}"
+    )
+    return _support_discord_send_message(thread_id, content, headers, attachments=attachments), thread_id
+
+
+@app.get("/api/support/attachment/<attachment_id>")
+@login_required
+def api_support_attachment(attachment_id: str):
+    user_id = str(getattr(current_user, "id", "") or getattr(current_user, "pw_hash", ""))
+    if not user_id:
+        return jsonify({"ok": False, "error": "unauthorized"}), 401
+    data = _support_load()
+    my_ticket = _support_get_my_open_ticket(data, user_id)
+    owned_ticket_ids = set()
+    if my_ticket:
+        owned_ticket_ids.add(int(my_ticket.get("id") or 0))
+    for t in (data.get("tickets") or []):
+        if str(t.get("user_id") or "") == user_id:
+            owned_ticket_ids.add(int(t.get("id") or 0))
+
+    target = None
+    for m in (data.get("messages") or []):
+        if int(m.get("ticket_id") or 0) not in owned_ticket_ids:
+            continue
+        for a in (m.get("attachments") or []):
+            if str(a.get("id") or "") == str(attachment_id):
+                target = a
+                break
+        if target:
+            break
+    if not target:
+        return jsonify({"ok": False, "error": "not found"}), 404
+    rel = str(target.get("path") or "")
+    abs_path = os.path.join(_support_upload_dir(), rel)
+    if not os.path.exists(abs_path):
+        return jsonify({"ok": False, "error": "missing file"}), 404
+    return send_file(abs_path, mimetype=target.get("mime") or "application/octet-stream", as_attachment=False, download_name=target.get("name") or "attachment")
+
+
 @app.post("/api/support/ticket/open")
 @login_required
 def api_support_open_ticket():
-    payload = request.get_json(silent=True) or {}
+    is_multipart = request.content_type and "multipart/form-data" in request.content_type
+    payload = request.form if is_multipart else (request.get_json(silent=True) or {})
     message = str(payload.get("message") or "").strip()
     display_name = str(payload.get("display_name") or "").strip()
-    if not message:
-        return jsonify({"ok": False, "error": "Το μήνυμα είναι υποχρεωτικό."}), 400
+    files = request.files.getlist("files") if is_multipart else []
+
+    if not message and not files:
+        return jsonify({"ok": False, "error": "Το μήνυμα ή αρχείο είναι υποχρεωτικό."}), 400
     if not display_name:
         return jsonify({"ok": False, "error": "Δήλωσε όνομα πριν ξεκινήσεις συνομιλία."}), 400
 
@@ -10147,39 +10311,69 @@ def api_support_open_ticket():
             "group_name": getattr(grp, "name", None) if grp else None,
             "created_at": _support_now_iso(),
             "updated_at": _support_now_iso(),
+            "support_typing_until": None,
+            "last_support_read_at": None,
+            "last_user_read_at": None,
         }
         data["tickets"].append(ticket)
     else:
         ticket["display_name"] = display_name[:120]
 
-    data["messages"].append({
+    attachments = _support_store_uploaded_files(files)
+    msg_obj = {
+        "id": _support_next_message_id(data),
         "ticket_id": ticket["id"],
         "sender": "user",
         "content": message[:4000],
+        "attachments": attachments,
         "timestamp": _support_now_iso(),
-    })
+        "discord_delivered": False,
+        "discord_delivered_at": None,
+        "read_by_support_at": None,
+        "read_by_user_at": None,
+    }
+    data["messages"].append(msg_obj)
     ticket["updated_at"] = _support_now_iso()
 
-    if not ticket.get("discord_thread_id"):
-        thread_id = _support_discord_create_thread(ticket, message)
-        if thread_id:
-            ticket["discord_thread_id"] = thread_id
+    delivered, _ = _support_discord_deliver_message(ticket, message or "(attachment)", attachments=attachments)
+    msg_obj["discord_delivered"] = bool(delivered)
+    if delivered:
+        msg_obj["discord_delivered_at"] = _support_now_iso()
 
     _support_save(data)
-    return jsonify({"ok": True, "ticket": ticket})
+    return jsonify({"ok": True, "ticket": ticket, "discord_delivered": bool(delivered), "message": msg_obj})
 
 
 @app.get("/api/support/ticket/me")
 @login_required
 def api_support_my_ticket():
     user_id = str(getattr(current_user, "id", "") or getattr(current_user, "pw_hash", ""))
+    mark_read = str(request.args.get("mark_read") or "0") in ("1", "true", "yes")
     data = _support_load()
     ticket = _support_get_my_open_ticket(data, user_id)
     if not ticket:
-        return jsonify({"ok": True, "ticket": None, "messages": []})
+        return jsonify({"ok": True, "ticket": None, "messages": [], "presence": {"support_typing": False}})
+
     msgs = [m for m in (data.get("messages") or []) if int(m.get("ticket_id") or 0) == int(ticket.get("id") or 0)]
     msgs.sort(key=lambda x: str(x.get("timestamp") or ""))
-    return jsonify({"ok": True, "ticket": ticket, "messages": msgs[-100:]})
+
+    changed = False
+    if mark_read:
+        now = _support_now_iso()
+        for m in msgs:
+            if m.get("sender") == "support" and not m.get("read_by_user_at"):
+                m["read_by_user_at"] = now
+                changed = True
+        ticket["last_user_read_at"] = now
+        changed = True
+
+    typing_until = str(ticket.get("support_typing_until") or "")
+    support_typing = bool(typing_until and typing_until > _support_now_iso())
+
+    if changed:
+        _support_save(data)
+
+    return jsonify({"ok": True, "ticket": ticket, "messages": msgs[-100:], "presence": {"support_typing": support_typing}})
 
 
 @app.post("/api/support/ticket/close")
@@ -10209,8 +10403,6 @@ def api_support_discord_reply():
     payload = request.get_json(silent=True) or {}
     action = str(payload.get("action") or "reply").strip().lower()
     content = str(payload.get("content") or "").strip()
-    if action == "reply" and not content:
-        return jsonify({"ok": False, "error": "missing content"}), 400
 
     data = _support_load()
     ticket = None
@@ -10230,13 +10422,52 @@ def api_support_discord_reply():
     if ticket is None:
         return jsonify({"ok": False, "error": "ticket not found"}), 404
 
+    now = _support_now_iso()
+    if action == "typing_start":
+        ttl = max(5, min(45, int(payload.get("ttl_sec") or 15)))
+        expires = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=ttl)
+        ticket["support_typing_until"] = expires.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        _support_save(data)
+        return jsonify({"ok": True, "typing": True})
+
+    if action == "typing_stop":
+        ticket["support_typing_until"] = None
+        _support_save(data)
+        return jsonify({"ok": True, "typing": False})
+
+    if action == "read":
+        for m in (data.get("messages") or []):
+            if int(m.get("ticket_id") or 0) != int(ticket.get("id") or 0):
+                continue
+            if m.get("sender") == "user" and not m.get("read_by_support_at"):
+                m["read_by_support_at"] = now
+        ticket["last_support_read_at"] = now
+        _support_save(data)
+        return jsonify({"ok": True, "read": True})
+
+    attachments = []
+    for a in (payload.get("attachments") or []):
+        if not isinstance(a, dict):
+            continue
+        attachments.append({
+            "id": str(a.get("id") or secrets.token_hex(8)),
+            "name": str(a.get("filename") or a.get("name") or "attachment"),
+            "url": str(a.get("url") or "").strip(),
+            "mime": str(a.get("content_type") or a.get("mime") or "application/octet-stream"),
+            "size": int(a.get("size") or 0),
+            "path": None,
+        })
+
     if action == "close":
-        if content:
+        if content or attachments:
             data["messages"].append({
+                "id": _support_next_message_id(data),
                 "ticket_id": int(ticket.get("id") or 0),
                 "sender": "support",
                 "content": content[:4000],
-                "timestamp": _support_now_iso(),
+                "attachments": attachments,
+                "timestamp": now,
+                "read_by_user_at": None,
             })
         _support_close_ticket_record(ticket, closed_by="admin")
         _support_save(data)
@@ -10244,16 +10475,28 @@ def api_support_discord_reply():
             _support_discord_archive_thread(thread_id)
         return jsonify({"ok": True, "closed": True})
 
+    if action == "reply" and not content and not attachments:
+        return jsonify({"ok": False, "error": "missing content"}), 400
+
     data["messages"].append({
+        "id": _support_next_message_id(data),
         "ticket_id": int(ticket.get("id") or 0),
         "sender": "support",
         "content": content[:4000],
-        "timestamp": _support_now_iso(),
+        "attachments": attachments,
+        "timestamp": now,
+        "read_by_user_at": None,
     })
-    ticket["updated_at"] = _support_now_iso()
+    ticket["support_typing_until"] = None
+    ticket["updated_at"] = now
+
+    for m in (data.get("messages") or []):
+        if int(m.get("ticket_id") or 0) == int(ticket.get("id") or 0) and m.get("sender") == "user" and not m.get("read_by_support_at"):
+            m["read_by_support_at"] = now
+    ticket["last_support_read_at"] = now
+
     _support_save(data)
     return jsonify({"ok": True})
-
 
 
 def _normalize_backup_member(name: str) -> str:

--- a/templates/base.html
+++ b/templates/base.html
@@ -2914,16 +2914,33 @@
 #helpBotFab{position:fixed;right:20px;bottom:20px;z-index:100200;background:#2563eb;color:#fff;border:none;border-radius:9999px;width:56px;height:56px;box-shadow:0 8px 24px rgba(37,99,235,.35);cursor:pointer;font-size:22px;}
 #helpBotFab.has-unread{animation:helpBotPulse 1.3s ease-in-out infinite;}
 #helpBotBadge{position:absolute;right:-2px;top:-2px;min-width:20px;height:20px;border-radius:9999px;background:#ef4444;color:#fff;font-size:11px;display:none;align-items:center;justify-content:center;padding:0 5px;border:2px solid #fff;}
-#helpBotPanel{position:fixed;right:20px;bottom:86px;z-index:100200;width:min(92vw,360px);height:min(70vh,520px);background:#fff;border:1px solid #e5e7eb;border-radius:14px;display:none;flex-direction:column;box-shadow:0 20px 45px rgba(0,0,0,.2);overflow:hidden;}
+#helpBotPanel{position:fixed;right:20px;bottom:86px;z-index:100200;width:min(92vw,380px);height:min(75vh,560px);background:#fff;border:1px solid #e5e7eb;border-radius:14px;display:none;flex-direction:column;box-shadow:0 20px 45px rgba(0,0,0,.2);overflow:hidden;}
 #helpBotHead{padding:10px 12px;background:#0f172a;color:#fff;font-weight:600;display:flex;justify-content:space-between;align-items:center;}
 #helpBotMessages{flex:1;overflow:auto;padding:10px;background:#f8fafc;}
-.help-msg{margin-bottom:8px;padding:8px 10px;border-radius:10px;max-width:90%;white-space:pre-wrap;word-break:break-word;font-size:13px;}
+.help-msg{margin-bottom:8px;padding:8px 10px;border-radius:10px;max-width:92%;white-space:pre-wrap;word-break:break-word;font-size:13px;}
 .help-msg.user{margin-left:auto;background:#dbeafe;color:#1e3a8a;}
 .help-msg.support{margin-right:auto;background:#e2e8f0;color:#0f172a;}
-#helpBotForm{display:flex;gap:8px;padding:10px;border-top:1px solid #e5e7eb;}
+.help-meta{margin-top:4px;font-size:10px;opacity:.8;}
+.help-attachments{margin-top:6px;display:flex;flex-direction:column;gap:4px;}
+.help-attachments a{font-size:12px;text-decoration:underline;color:inherit;opacity:.95;}
+#helpBotPresence{padding:0 10px 8px 10px;font-size:11px;color:#64748b;min-height:18px;}
+#helpBotForm{display:flex;gap:8px;padding:10px;border-top:1px solid #e5e7eb;align-items:center;}
 #helpBotInput{flex:1;border:1px solid #cbd5e1;border-radius:8px;padding:8px 10px;font-size:13px;}
 #helpBotName{border:1px solid #cbd5e1;border-radius:8px;padding:8px 10px;font-size:13px;width:100%;margin:10px 10px 0 10px;max-width:calc(100% - 20px);}
+#helpBotFile{display:none;}
+#helpBotFileBtn{border:1px solid #cbd5e1;background:#f1f5f9;color:#0f172a;border-radius:8px;padding:7px 9px;cursor:pointer;font-size:12px;}
+#helpBotFileState{padding:0 10px 8px 10px;font-size:11px;color:#64748b;min-height:17px;}
 #helpBotSend{background:#2563eb;color:#fff;border:none;border-radius:8px;padding:8px 12px;cursor:pointer;}
+html[data-theme="dark"] #helpBotPanel{background:#111827;border-color:#334155;box-shadow:0 20px 45px rgba(0,0,0,.55);}
+html[data-theme="dark"] #helpBotHead{background:#020617;color:#e2e8f0;border-bottom:1px solid #334155;}
+html[data-theme="dark"] #helpBotMessages{background:#0b1220;color:#e2e8f0;}
+html[data-theme="dark"] .help-msg.user{background:#1d4ed8;color:#dbeafe;}
+html[data-theme="dark"] .help-msg.support{background:#1f2937;color:#e5e7eb;}
+html[data-theme="dark"] #helpBotForm{border-top-color:#334155;background:#0f172a;}
+html[data-theme="dark"] #helpBotInput,html[data-theme="dark"] #helpBotName{background:#1e293b;color:#e2e8f0;border-color:#475569;}
+html[data-theme="dark"] #helpBotInput::placeholder,html[data-theme="dark"] #helpBotName::placeholder{color:#94a3b8;}
+html[data-theme="dark"] #helpBotFileBtn{border-color:#475569;background:#1e293b;color:#e2e8f0;}
+html[data-theme="dark"] #helpBotPresence,html[data-theme="dark"] #helpBotFileState{color:#94a3b8;}
 @keyframes helpBotPulse{0%{transform:scale(1)}50%{transform:scale(1.08)}100%{transform:scale(1)}}
 </style>
 <button id="helpBotFab" type="button" title="Help / Support">
@@ -2944,7 +2961,11 @@
   </div>
   <input id="helpBotName" type="text" placeholder="Δήλωσε όνομα (θα εμφανίζεται στο support)" maxlength="120" />
   <div id="helpBotMessages"></div>
+  <div id="helpBotPresence"></div>
+  <div id="helpBotFileState"></div>
   <form id="helpBotForm">
+    <label id="helpBotFileBtn" for="helpBotFile">📎</label>
+    <input id="helpBotFile" type="file" multiple accept="image/*,.pdf,.txt,.doc,.docx,.xls,.xlsx,.zip" />
     <input id="helpBotInput" type="text" placeholder="Γράψε το μήνυμά σου…" maxlength="2000" />
     <button id="helpBotSend" type="submit">Αποστολή</button>
   </form>
@@ -2958,26 +2979,53 @@
   const titleEl=document.getElementById('helpBotTitle');
   const badge=document.getElementById('helpBotBadge');
   const threadLabel=document.getElementById('helpBotThreadLabel');
+  const presenceEl=document.getElementById('helpBotPresence');
+  const fileStateEl=document.getElementById('helpBotFileState');
   const form=document.getElementById('helpBotForm');
   const input=document.getElementById('helpBotInput');
   const nameInput=document.getElementById('helpBotName');
+  const fileInput=document.getElementById('helpBotFile');
   const box=document.getElementById('helpBotMessages');
   let open=false;
   let poller=null;
+  let lastPresence={support_typing:false};
   const NAME_KEY='support_display_name';
   const SEEN_KEY='support_last_seen';
   let lastTicket=null;
 
   function esc(s){return String(s||'').replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;');}
+  function formatStatus(m){
+    if(m.sender!=='user') return '';
+    if(m.read_by_support_at) return 'Διαβάστηκε από support';
+    if(m.discord_delivered_at || m.discord_delivered) return 'Παραλήφθηκε από Discord';
+    return 'Σε αναμονή αποστολής στο Discord';
+  }
   function render(messages){
     if(!box) return;
-    box.innerHTML = (messages||[]).map(m=>`<div class="help-msg ${m.sender==='support'?'support':'user'}">${esc(m.content)}</div>`).join('');
+    box.innerHTML = (messages||[]).map(m=>{
+      const attachments = (m.attachments||[]).map(a=>{
+        const href = esc(a.url||'#');
+        const nm = esc(a.name||'attachment');
+        return `<a href="${href}" target="_blank" rel="noopener noreferrer">📎 ${nm}</a>`;
+      }).join('');
+      const meta = formatStatus(m);
+      return `<div class="help-msg ${m.sender==='support'?'support':'user'}">${esc(m.content||'')}${attachments?`<div class="help-attachments">${attachments}</div>`:''}${meta?`<div class="help-meta">${esc(meta)}</div>`:''}</div>`;
+    }).join('');
     box.scrollTop = box.scrollHeight;
   }
 
   function parseTs(ts){
     const v = Date.parse(ts||'');
     return Number.isFinite(v) ? v : 0;
+  }
+
+  function updatePresence(){
+    if(!presenceEl) return;
+    if(lastPresence && lastPresence.support_typing){
+      presenceEl.textContent = 'Ο support agent πληκτρολογεί…';
+    } else {
+      presenceEl.textContent = '';
+    }
   }
 
   function updateBadge(messages){
@@ -3019,31 +3067,50 @@
     }
   }
 
+  function updateSelectedFiles(){
+    if(!fileStateEl) return;
+    const f = (fileInput && fileInput.files) ? Array.from(fileInput.files) : [];
+    if(!f.length){ fileStateEl.textContent=''; return; }
+    fileStateEl.textContent = `Επισυναπτόμενα: ${f.map(x=>x.name).join(', ')}`;
+  }
+
   async function refresh(){
     try{
-      const r=await fetch('/api/support/ticket/me',{credentials:'same-origin'});
+      const r=await fetch(`/api/support/ticket/me?mark_read=${open?'1':'0'}`,{credentials:'same-origin'});
       if(!r.ok) return;
       const j=await r.json();
       lastTicket = j.ticket || null;
+      lastPresence = j.presence || {support_typing:false};
       updateTitle(lastTicket);
       render(j.messages||[]);
       updateBadge(j.messages||[]);
+      updatePresence();
       if(open){ markSeen(j.messages||[]); }
     }catch(_e){}
   }
 
   async function sendMsg(msg){
     const displayName=(nameInput&&nameInput.value||'').trim();
+    const files = (fileInput && fileInput.files) ? Array.from(fileInput.files) : [];
     if(!displayName){ throw new Error('Δήλωσε πρώτα όνομα support.'); }
+    if(!msg && !files.length){ throw new Error('Γράψε μήνυμα ή πρόσθεσε αρχείο.'); }
     try{ localStorage.setItem(NAME_KEY, displayName); }catch(_e){}
+
+    const fd = new FormData();
+    fd.append('message', msg || '');
+    fd.append('display_name', displayName);
+    files.forEach(f => fd.append('files', f));
+
     const r=await fetch('/api/support/ticket/open',{
       method:'POST',
       credentials:'same-origin',
-      headers:{'Content-Type':'application/json'},
-      body:JSON.stringify({message:msg, display_name:displayName})
+      body:fd
     });
     const j=await r.json().catch(()=>({}));
     if(!r.ok || !j.ok) throw new Error((j&&j.error)||'Σφάλμα αποστολής');
+    if(j.discord_delivered===false){ throw new Error('Το ticket αποθηκεύτηκε αλλά απέτυχε η αποστολή στο Discord.'); }
+    if(fileInput) fileInput.value='';
+    updateSelectedFiles();
   }
 
   function setOpen(v){
@@ -3056,6 +3123,7 @@
   }
 
   fab&&fab.addEventListener('click',()=>setOpen(!open));
+  fileInput&&fileInput.addEventListener('change', updateSelectedFiles);
   try{
     const savedName = localStorage.getItem(NAME_KEY) || '';
     if(savedName && nameInput) nameInput.value = savedName;
@@ -3076,10 +3144,9 @@
   form&&form.addEventListener('submit', async (e)=>{
     e.preventDefault();
     const msg=(input&&input.value||'').trim();
-    if(!msg) return;
-    if(input) input.value='';
     try{
       await sendMsg(msg);
+      if(input) input.value='';
       await refresh();
       markSeen([]);
     }catch(err){ alert(err.message||err); }
@@ -3087,6 +3154,7 @@
 })();
 </script>
 {% endif %}
+
 
 <!-- Sync progress overlay (inserted by server to show firebase pull progress) -->
 <div id="syncProgressOverlay" style="display:none;position:fixed;left:0;top:0;right:0;bottom:0;z-index:99999;align-items:center;justify-content:center;background:rgba(0,0,0,0.45)">


### PR DESCRIPTION
### Motivation
- Bring Discord replies and support agent state into the ScanmyData UI so agent replies appear in the user chat panel.
- Show delivery/read/typing status to users and allow users to attach files/photos just like Messenger.
- Persist attachments server-side and forward them to Discord when possible for a consistent two-way support flow.

### Description
- Added backend helpers: `_support_upload_dir`, `_support_store_uploaded_files`, and `_support_next_message_id` to persist uploaded files and assign stable IDs and URLs.
- Extended message model and ticket storage to track `discord_delivered`, `discord_delivered_at`, `read_by_support_at`, `read_by_user_at`, `support_typing_until`, and added `next_message_id` bookkeeping.
- Enhanced Discord bridge API: `_support_discord_send_message`, `_support_discord_create_thread`, and `_support_discord_deliver_message` now accept and forward `attachments` when possible, and properly handle multipart Discord uploads.
- Added secure attachment serving endpoint `GET /api/support/attachment/<id>` that only serves files to authenticated owners of the ticket.
- Updated `POST /api/support/ticket/open` to accept multipart form uploads (`files`) and persist attachments, then forward attachments and message to Discord; response now includes the saved `message` object.
- Extended `GET /api/support/ticket/me` to provide `presence.support_typing` and a `mark_read` query parameter to mark support messages as read by the user.
- Implemented `/api/support/discord/reply` actions: `typing_start`, `typing_stop`, `read`, `reply`, and `close` to allow a Discord webhook/bridge to update ticket state and post support messages (including attachments) back into the ScanmyData storage for UI consumption.
- Frontend updates in `templates/base.html` for the Help/Support widget: added file picker, selected-files state, rendering of attachments as links, message meta (pending/delivered/read) indicators, support typing presence, and styling tweaks (size/dark-mode consistency).

### Testing
- Ran `python3 -m py_compile app.py` to verify Python syntax and it succeeded.
- Attempted to run `python3 app.py` for runtime/browser verification but the process failed in this environment due to a missing dependency (`werkzeug`), so full end-to-end verification and screenshot could not be completed.
- Manual static checks performed on modified template JS to ensure the new UI calls the multipart API and reads `presence.support_typing` and message metadata (no automated UI tests available in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698da332f27c8328a29893aeeef61a87)