### PR TITLE
Fix support ticket webhook handling, dark-mode warning, and redesign Groups UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -10502,8 +10502,9 @@ def api_support_my_ticket():
         ticket["last_user_read_at"] = now
         changed = True
 
-    typing_until = str(ticket.get("support_typing_until") or "")
-    support_typing = bool(typing_until and typing_until > _support_now_iso())
+    typing_until_dt = _support_parse_iso_utc(ticket.get("support_typing_until"))
+    now_dt = datetime.datetime.now(datetime.timezone.utc)
+    support_typing = bool(typing_until_dt and typing_until_dt > now_dt)
 
     if changed:
         _support_save(data)
@@ -10528,6 +10529,47 @@ def api_support_close_ticket():
     return jsonify({"ok": True, "closed": True, "ticket": ticket})
 
 
+def _support_find_ticket_for_payload(data: Dict[str, Any], payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    tickets = data.get("tickets") or []
+    candidates = []
+
+    for key in ("ticket_id", "ticket", "id"):
+        value = payload.get(key)
+        if value is None:
+            continue
+        try:
+            candidates.append(("id", int(str(value).strip())))
+        except Exception:
+            pass
+
+    for key in ("discord_thread_id", "thread_id", "channel_id"):
+        value = str(payload.get(key) or "").strip()
+        if value:
+            candidates.append(("thread", value))
+
+    for match_type, value in candidates:
+        for t in tickets:
+            if match_type == "id" and int(t.get("id") or 0) == int(value):
+                return t
+            if match_type == "thread" and str(t.get("discord_thread_id") or "").strip() == str(value):
+                return t
+    return None
+
+
+def _support_parse_iso_utc(value: str) -> Optional[datetime.datetime]:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        dt = datetime.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return dt.astimezone(datetime.timezone.utc)
+    except Exception:
+        return None
+
+
+
 @app.post("/api/support/discord/reply")
 def api_support_discord_reply():
     secret = (os.getenv("SUPPORT_WEBHOOK_SECRET") or "").strip()
@@ -10540,22 +10582,24 @@ def api_support_discord_reply():
     content = str(payload.get("content") or "").strip()
 
     data = _support_load()
-    ticket = None
-    ticket_id = payload.get("ticket_id")
-    thread_id = str(payload.get("discord_thread_id") or "").strip()
-
-    if ticket_id is not None:
-        for t in (data.get("tickets") or []):
-            if int(t.get("id") or 0) == int(ticket_id):
-                ticket = t
-                break
-    if ticket is None and thread_id:
-        for t in (data.get("tickets") or []):
-            if str(t.get("discord_thread_id") or "") == thread_id:
-                ticket = t
-                break
+    ticket = _support_find_ticket_for_payload(data, payload)
     if ticket is None:
         return jsonify({"ok": False, "error": "ticket not found"}), 404
+
+    thread_id = str(ticket.get("discord_thread_id") or payload.get("discord_thread_id") or payload.get("thread_id") or payload.get("channel_id") or "").strip()
+
+    action_aliases = {
+        "typing": "typing_start",
+        "typing_on": "typing_start",
+        "start_typing": "typing_start",
+        "typing_end": "typing_stop",
+        "stop_typing": "typing_stop",
+        "typing_off": "typing_stop",
+        "mark_read": "read",
+        "seen": "read",
+        "message_read": "read",
+    }
+    action = action_aliases.get(action, action)
 
     now = _support_now_iso()
     if action == "typing_start":

--- a/templates/auth/groups.html
+++ b/templates/auth/groups.html
@@ -1,319 +1,284 @@
-﻿{% extends 'base.html' %}
+{% extends 'base.html' %}
 
 {% block title %}Ομάδες{% endblock %}
 
 {% block content %}
-  <div class="content-wrap">
-    <div class="flex items-center justify-between mb-4">
-      <h1 class="text-xl font-semibold">Ομάδες</h1>
-      <div>Συνδεδεμένος χρήστης → <strong>{{ current_user.username }}</strong></div>
+<div class="content-wrap groups-page">
+  <style>
+    .groups-page{max-width:1200px;margin:0 auto;padding:0 0 18px;}
+    .groups-hero{display:flex;justify-content:space-between;gap:16px;align-items:flex-start;margin-bottom:20px;flex-wrap:wrap;}
+    .groups-title h1{font-size:1.5rem;font-weight:700;margin:0 0 6px;}
+    .groups-title p{margin:0;color:#475569;}
+    [data-theme="dark"] .groups-title p{color:#94a3b8;}
+
+    .groups-actions{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px;margin-bottom:20px;}
+    .groups-action-card{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:14px;box-shadow:0 6px 18px rgba(15,23,42,.06);}
+    .groups-action-card h2{margin:0 0 8px;font-size:1rem;font-weight:700;}
+    .groups-action-card p{margin:0 0 12px;font-size:.92rem;color:#64748b;}
+    [data-theme="dark"] .groups-action-card{background:#0f172a;border-color:#334155;box-shadow:none;}
+    [data-theme="dark"] .groups-action-card p{color:#94a3b8;}
+
+    .btn-primary{background:#0284c7;color:#fff;border:none;border-radius:10px;padding:9px 14px;font-weight:600;cursor:pointer;}
+    .btn-primary:hover{background:#0369a1;}
+    .btn-ghost{background:#e2e8f0;color:#0f172a;border:none;border-radius:10px;padding:9px 14px;font-weight:600;cursor:pointer;}
+    [data-theme="dark"] .btn-ghost{background:#334155;color:#e2e8f0;}
+
+    .groups-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:14px;}
+    .group-card{background:#fff;border:1px solid #e2e8f0;border-radius:14px;padding:14px;display:flex;flex-direction:column;gap:10px;}
+    .group-card.selected{border-color:#0891b2;box-shadow:0 0 0 2px rgba(8,145,178,.22);}
+    [data-theme="dark"] .group-card{background:#0b1220;border-color:#334155;}
+    [data-theme="dark"] .group-card.selected{box-shadow:0 0 0 2px rgba(34,211,238,.24);}
+    .group-top{display:flex;justify-content:space-between;gap:10px;align-items:flex-start;}
+    .group-name{font-size:1.05rem;font-weight:700;margin:0;}
+    .group-folder{font-size:.8rem;color:#64748b;word-break:break-all;}
+    [data-theme="dark"] .group-folder{color:#94a3b8;}
+    .group-badge{font-size:.72rem;background:#ecfeff;color:#0e7490;border:1px solid #a5f3fc;border-radius:999px;padding:2px 9px;}
+
+    .admin-list,.members-list{display:flex;flex-wrap:wrap;gap:6px;}
+    .pill{display:inline-flex;align-items:center;gap:6px;background:#f8fafc;border:1px solid #cbd5e1;border-radius:999px;padding:4px 10px;font-size:.82rem;}
+    .pill small{color:#64748b;}
+    [data-theme="dark"] .pill{background:#1e293b;border-color:#475569;color:#e2e8f0;}
+    [data-theme="dark"] .pill small{color:#94a3b8;}
+
+    .remove-member-btn{border:none;background:#fee2e2;color:#991b1b;border-radius:999px;padding:2px 7px;cursor:pointer;font-weight:700;}
+    .remove-member-btn:hover{background:#fecaca;}
+    .leave-group-btn{background:#fee2e2;color:#7f1d1d;border:1px solid #fca5a5;border-radius:10px;padding:6px 10px;font-weight:600;cursor:pointer;}
+    [data-theme="dark"] .leave-group-btn{background:#7f1d1d;color:#fee2e2;border-color:#991b1b;}
+
+    .gm-modal-backdrop{display:none;position:fixed;inset:0;background:rgba(2,6,23,.58);align-items:center;justify-content:center;z-index:80;padding:18px;}
+    .gm-modal{width:min(760px,100%);background:#fff;border-radius:14px;border:1px solid #dbeafe;padding:20px;}
+    [data-theme="dark"] .gm-modal{background:#0f172a;border-color:#334155;color:#e2e8f0;}
+    .gm-modal h3{margin:0 0 8px;}
+    .gm-help{margin:0 0 12px;color:#64748b;font-size:.9rem;}
+    [data-theme="dark"] .gm-help{color:#94a3b8;}
+    .gm-field{display:flex;flex-direction:column;gap:6px;margin-bottom:10px;}
+    .gm-field label{font-size:.86rem;font-weight:600;}
+    .gm-field input,.gm-field select{padding:10px;border:1px solid #cbd5e1;border-radius:10px;background:#fff;}
+    [data-theme="dark"] .gm-field input,[data-theme="dark"] .gm-field select{background:#1e293b;border-color:#475569;color:#e2e8f0;}
+    .gm-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:12px;}
+    .user-check-result{font-size:.82rem;min-height:20px;}
+  </style>
+
+  <div class="groups-hero">
+    <div class="groups-title">
+      <h1>Διαχείριση Ομάδων</h1>
+      <p>Συνδεδεμένος χρήστης: <strong>{{ current_user.username }}</strong> · Διπλό κλικ σε κάρτα για ενεργή ομάδα.</p>
     </div>
+  </div>
 
-    <!-- Flash messages are shown in base.html, no need to duplicate here -->
+  <div class="groups-actions">
+    <section class="groups-action-card">
+      <h2>Δημιουργία ομάδας</h2>
+      <p>Φτιάξτε νέα ομάδα με μοναδικό όνομα. Θα δημιουργηθεί ξεχωριστός φάκελος δεδομένων.</p>
+      <button id="open-create" class="btn-primary" type="button">+ Νέα ομάδα</button>
+    </section>
 
-    <style>
-      ul li.selected { 
-        background: #dbeafe; 
-        border: 2px solid #0ea5e9;
-        border-width: 2px;
-      }
-      
-      /* Remove member button styling */
-      .remove-member-btn {
-        border: none;
-        background: #fee2e2;
-        color: #991b1b;
-        cursor: pointer;
-        padding: 2px 8px;
-        border-radius: 4px;
-        font-weight: 600;
-        transition: all 0.2s;
-      }
-      .remove-member-btn:hover {
-        background: #fca5a5;
-        color: #7f1d1d;
-      }
-      [data-theme="dark"] .remove-member-btn {
-        background: #7f1d1d;
-        color: #fee2e2;
-      }
-      [data-theme="dark"] .remove-member-btn:hover {
-        background: #991b1b;
-        color: #ffffff;
-      }
+    <section class="groups-action-card">
+      <h2>Ανάθεση χρήστη</h2>
+      <p>Αναζητήστε χρήστη με username/email και ορίστε ρόλο (Μέλος ή Διαχειριστής).</p>
+      <button id="open-assign" class="btn-primary" type="button">Ανάθεση χρήστη</button>
+    </section>
+  </div>
 
-      /* Member pill styling */
-      .member-pill {
-        background: #f3f4f6;
-        border: 1px solid #d1d5db;
-      }
-      [data-theme="dark"] .member-pill {
-        background: #374151;
-        border: 1px solid #4b5563;
-        color: #e5e7eb;
-      }
-
-      /* Dark mode adjustments for selection */
-      [data-theme="dark"] ul li.selected {
-        background-color: #164e63; /* darker teal for dark mode */
-        border: 2px solid #0891b2;
-        border-width: 2px;
-        color: #e0f2fe;
-      }
-
-      /* leave-group button should match logout color */
-      .leave-group-btn {
-        background: #fee2e2;
-        color: #7f1d1d;
-        border: 1px solid #fca5a5;
-        font-weight: 600;
-        transition: all 0.2s;
-      }
-      .leave-group-btn:hover {
-        background: #fca5a5;
-        color: #991b1b;
-      }
-      [data-theme="dark"] .leave-group-btn {
-        background: #7f1d1d;
-        color: #fee2e2;
-        border: 1px solid #991b1b;
-      }
-      [data-theme="dark"] .leave-group-btn:hover {
-        background: #991b1b;
-        color: #ffffff;
-      }
-
-      /* Modal visual improvements έΑΦ larger, more readable */
-      .gm-modal-backdrop {
-        display: none; position: fixed; inset:0; background: rgba(0,0,0,0.55); align-items:center; justify-content:center; z-index:60;
-      }
-      .gm-modal {
-        background: #fff; padding: 28px; border-radius:10px; width: calc(100% - 48px); max-width: 900px; margin: 28px auto; box-shadow: 0 10px 30px rgba(2,6,23,0.2); color: #0f172a;
-      }
-
-      /* Dark theme modal colors */
-      [data-theme="dark"] .gm-modal { background: var(--bg-secondary); color: var(--text-primary); border: 1px solid #374151; }
-      [data-theme="dark"] .gm-modal-backdrop { background: rgba(2,6,23,0.6); }
-
-      .gm-modal h3 { margin-top: 0; margin-bottom: 8px; font-size:1.1rem; }
-      .gm-modal .actions { margin-top: 14px; display:flex; gap:8px; justify-content:flex-end; }
-      .gm-modal .muted-btn { background: #e5e7eb; color:#111827; }
-      [data-theme="dark"] .gm-modal .muted-btn { background:#374151; color:#e5e7eb; }
-    </style>
-
-    <div class="grid grid-cols-2 gap-6">
-      <div>
-        <h2 class="font-medium mb-2">Φιλική ομάδα</h2>
-        <button id="open-create" class="px-4 py-2 rounded bg-sky-600 text-white">Δημιουργία ομάδας</button>
-      </div>
-
-      <div>
-        <h2 class="font-medium mb-2">Ανάθεση χρήστη σε ομάδα</h2>
-        <button id="open-assign" class="px-4 py-2 rounded bg-sky-600 text-white">Ανάθεση χρήστη</button>
-      </div>
-    </div>
-
-    <!-- Create modal (larger, styled) -->
-    <div id="modal-create" class="gm-modal-backdrop">
-      <div class="gm-modal">
-        <h3>Δημιουργία ομάδας</h3>
-        <form method="post" action="{{ url_for('auth.create_group') }}" class="grid gap-3">
-          <input type="text" name="name" placeholder="Όνομα ομάδας" class="px-3 py-2 border rounded" required />
-          <div class="actions">
-            <button type="submit" class="px-4 py-2 rounded bg-sky-600 text-white">Δημιουργία</button>
-            <button type="button" id="close-create" class="px-4 py-2 rounded muted-btn">Άκυρο</button>
+  <div class="groups-grid">
+    {% for g in groups %}
+      <article class="group-card {% if session.get('active_group') == g.name %}selected{% endif %}" data-group-card="{{ g.name }}">
+        <div class="group-top">
+          <div>
+            <h3 class="group-name">{{ g.name }}</h3>
+            <div class="group-folder"><code>{{ g.data_folder }}</code></div>
           </div>
-        </form>
-      </div>
-    </div>
+          {% if session.get('active_group') == g.name %}<span class="group-badge">Ενεργή</span>{% endif %}
+        </div>
 
-    <!-- Assign modal (larger, styled) -->
-    <div id="modal-assign" class="gm-modal-backdrop">
-      <div class="gm-modal" style="max-width:720px;">
-        <h3>Ανάθεση χρήστη σε ομάδα</h3>
-        <form id="assign-form" method="post" action="{{ url_for('auth.assign_user_to_group') }}" class="grid gap-3">
-          <div class="flex items-center gap-2">
-            <input id="assign-username" type="text" name="username" placeholder="Όνομα χρήστη ή email" class="px-3 py-2 border rounded flex-1" />
-            <div id="user-check-result" class="text-sm"></div>
+        <div>
+          <strong style="font-size:.85rem;">Διαχειριστές</strong>
+          <div class="admin-list">
+            {% for u in g.admins() %}<span class="pill">{{ u.username }}</span>{% else %}<span class="pill">Κανένας</span>{% endfor %}
           </div>
-          <select name="group" class="px-3 py-2 border rounded" required>
-            <option value="">-- Επιλέξτε ομάδα --</option>
-            {% for g in admin_groups %}
-            <option value="{{ g.name }}">{{ g.name }}</option>
-            {% endfor %}
-          </select>
-          <select name="role" class="px-3 py-2 border rounded">
-            <option value="member">Μέλος</option>
-            <option value="admin">Διαχειριστής</option>
-          </select>
-          <div class="actions">
-            <button type="submit" class="px-4 py-2 rounded bg-sky-600 text-white">Ανάθεση</button>
-            <button type="button" id="close-assign" class="px-4 py-2 rounded muted-btn">Άκυρο</button>
-          </div>
-        </form>
-      </div>
-    </div>
+        </div>
 
-    <h3 class="mt-6 font-medium">Υπάρχουσες ομάδες</h3>
-    <ul class="mt-2 space-y-2">
-      {% for g in groups %}
-        <li class="px-3 py-2 border rounded {% if session.get('active_group') == g.name %}selected{% endif %}">
-          <div class="flex justify-between items-center">
-            <div><strong>{{ g.name }}</strong> → <code>{{ g.data_folder }}</code></div>
-            <div class="text-sm text-gray-600">Διαχειριστές: {% for u in g.admins() %}<span class="px-2 py-1 bg-gray-100 rounded">{{ u.username }}</span>{% if not loop.last %}, {% endif %}{% else %}κανένας{% endfor %}</div>
-          </div>
-          <div class="mt-2 text-sm">Μέλη:
+        <div>
+          <strong style="font-size:.85rem;">Μέλη</strong>
+          <div class="members-list">
             {% for ug in g.user_groups %}
-              <span class="member-pill inline-block px-2 py-1 border rounded mr-1" style="display:inline-flex;align-items:center;gap:6px;">
+              <span class="pill">
                 <span>{{ ug.user.username }}</span>
-                <em class="text-xs text-gray-500">({{ ug.role }})</em>
+                <small>{{ ug.role }}</small>
                 {% if current_user.is_authenticated and current_user.role_for_group(g) == 'admin' and ug.user.id != current_user.id %}
-                  <button class="remove-member-btn" data-username="{{ ug.user.username }}" data-group="{{ g.name }}" style="margin-left:6px;">✖</button>
+                  <button class="remove-member-btn" data-username="{{ ug.user.username }}" data-group="{{ g.name }}" type="button">✖</button>
                 {% endif %}
               </span>
             {% else %}
-              <span class="text-gray-500">κανένας μέλος</span>
+              <span class="pill">Δεν υπάρχουν μέλη</span>
             {% endfor %}
           </div>
-          <div class="mt-2">
-            {% if current_user.is_authenticated and (g in current_user.groups) %}
-              {% if current_user.role_for_group(g) == 'admin' %}
-                <button class="leave-group-btn px-2 py-1 border rounded" data-group="{{ g.name }}" data-is-admin="true">Διαγραφή</button>
-              {% else %}
-                <button class="leave-group-btn px-2 py-1 border rounded" data-group="{{ g.name }}" data-is-admin="false">Αποχώρηση</button>
-              {% endif %}
+        </div>
+
+        <div>
+          {% if current_user.is_authenticated and (g in current_user.groups) %}
+            {% if current_user.role_for_group(g) == 'admin' %}
+              <button class="leave-group-btn" data-group="{{ g.name }}" data-is-admin="true" type="button">Διαγραφή ομάδας</button>
+            {% else %}
+              <button class="leave-group-btn" data-group="{{ g.name }}" data-is-admin="false" type="button">Αποχώρηση</button>
             {% endif %}
-          </div>
-        </li>
-      {% else %}
-        <li class="text-gray-500">Δεν υπάρχει καμία ομάδα ακόμη</li>
-      {% endfor %}
-    </ul>
-
-    <script>
-      // Auto-check user when typing
-      let checkTimeout;
-      document.getElementById('assign-username').addEventListener('input', function(){
-        const q = this.value.trim();
-        const out = document.getElementById('user-check-result');
-        
-        // Clear previous timeout
-        if(checkTimeout) clearTimeout(checkTimeout);
-        
-        if(!q){
-          out.innerHTML = '';
-          return;
-        }
-        
-        // Debounce the check
-        checkTimeout = setTimeout(async function(){
-          try{
-            const resp = await fetch("{{ url_for('auth.lookup_user') }}?q=" + encodeURIComponent(q));
-            const data = await resp.json();
-            if(data.ok && data.found){
-              out.innerHTML = '<span style="color:green">✓ Βρέθηκε ο χρήστης</span>';
-            } else {
-              out.innerHTML = '<span style="color:orange">✗ Χρήστης δεν βρέθηκε</span>';
-            }
-          }catch(e){
-            out.innerHTML = '<span style="color:red">✗ Σφάλμα ελέγχου</span>';
-          }
-        }, 500); // Wait 500ms after user stops typing
-      });
-
-      // modal wiring
-      document.getElementById('open-create').addEventListener('click', function(){ document.getElementById('modal-create').style.display='flex'; });
-      document.getElementById('close-create').addEventListener('click', function(){ document.getElementById('modal-create').style.display='none'; });
-      document.getElementById('open-assign').addEventListener('click', function(){ document.getElementById('modal-assign').style.display='flex'; });
-      document.getElementById('close-assign').addEventListener('click', function(){ document.getElementById('modal-assign').style.display='none'; });
-
-      // group selection on double-click and highlight the selected group
-      document.querySelectorAll('ul li').forEach(function(li){
-        li.addEventListener('dblclick', function(){
-          const name = li.querySelector('strong')?.textContent?.trim();
-          if(!name) return;
-          
-          // Create a form to submit the selection (to show flash message)
-          const form = document.createElement('form');
-          form.method = 'POST';
-          form.action = "{{ url_for('auth.select_group') }}";
-          
-          const input = document.createElement('input');
-          input.type = 'hidden';
-          input.name = 'group';
-          input.value = name;
-          
-          form.appendChild(input);
-          document.body.appendChild(form);
-          form.submit();
-        });
-      });
-
-      // remove member buttons (delegated via data-attrs)
-      document.querySelectorAll('.remove-member-btn').forEach(function(btn){
-        btn.addEventListener('click', async function(ev){
-          ev.preventDefault();
-          const username = btn.dataset.username;
-          const group = btn.dataset.group;
-          const confirmed = await showModalConfirm('Επιβεβαίωση αφαίρεσης μέλους', 'Θέλετε να αφαιρέσετε τον ' + username + ' από την ομάδα ' + group + ';', 'Αφαίρεση', 'Άκυρο');
-          if(!confirmed) return;
-          
-          // Create a form to submit the removal (to show flash message)
-          const form = document.createElement('form');
-          form.method = 'POST';
-          form.action = "{{ url_for('auth.remove_member') }}";
-          
-          const usernameInput = document.createElement('input');
-          usernameInput.type = 'hidden';
-          usernameInput.name = 'username';
-          usernameInput.value = username;
-          
-          const groupInput = document.createElement('input');
-          groupInput.type = 'hidden';
-          groupInput.name = 'group';
-          groupInput.value = group;
-          
-          form.appendChild(usernameInput);
-          form.appendChild(groupInput);
-          document.body.appendChild(form);
-          form.submit();
-        });
-      });
-
-      // leave group buttons
-      document.querySelectorAll('.leave-group-btn').forEach(function(btn){
-        btn.addEventListener('click', async function(ev){
-          ev.preventDefault();
-          const group = btn.dataset.group;
-          const isAdmin = btn.dataset.isAdmin === 'true';
-          
-          let title, message, confirmText;
-          if (isAdmin) {
-            title = 'Διαγραφή ομάδας';
-            message = 'Θέλετε να διαγράψετε την ομάδα ' + group + '; Η ομάδα θα διαγραφεί εντελώς με όλα τα δεδομένα και τα μέλη θα αφαιρεθούν.';
-            confirmText = 'Διαγραφή';
-          } else {
-            title = 'Αποχώρηση από ομάδα';
-            message = 'Θέλετε να αποχωρήσετε από την ομάδα ' + group + ';';
-            confirmText = 'Αποχώρηση';
-          }
-          
-          const confirmed = await showModalConfirm(title, message, confirmText, 'Άκυρο');
-          if(!confirmed) return;
-          try{
-            const resp = await fetch("{{ url_for('auth.leave_group') }}", {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: 'group='+encodeURIComponent(group)});
-            const data = await resp.json();
-            if(data.ok){
-              // Reload the page to reflect session changes and group removal
-              window.location.reload();
-            } else {
-              await showModalAlert('Σφάλμα', (isAdmin ? 'Διαγραφή' : 'Αποχώρηση') + ' απέτυχε: '+(data.error||'άγνωστο σφάλμα'));
-            }
-          }catch(e){ await showModalAlert('Σφάλμα', 'Σφάλμα δικτύου'); }
-        });
-      });
-    </script>
-
-    <!-- logout link removed from this page (handled in side menu) -->
+          {% endif %}
+        </div>
+      </article>
+    {% else %}
+      <article class="group-card"><p>Δεν υπάρχει καμία ομάδα ακόμη.</p></article>
+    {% endfor %}
   </div>
+
+  <div id="modal-create" class="gm-modal-backdrop" aria-hidden="true">
+    <div class="gm-modal" role="dialog" aria-modal="true" aria-label="Δημιουργία ομάδας">
+      <h3>Δημιουργία νέας ομάδας</h3>
+      <p class="gm-help">Συμπληρώστε μοναδικό όνομα (π.χ. accounting-athens). Θα γίνει άμεση δημιουργία ομάδας.</p>
+      <form method="post" action="{{ url_for('auth.create_group') }}">
+        <div class="gm-field">
+          <label for="group-name-input">Όνομα ομάδας</label>
+          <input id="group-name-input" type="text" name="name" maxlength="120" placeholder="π.χ. finance-team" required />
+        </div>
+        <div class="gm-actions">
+          <button type="button" id="close-create" class="btn-ghost">Άκυρο</button>
+          <button type="submit" class="btn-primary">Δημιουργία</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div id="modal-assign" class="gm-modal-backdrop" aria-hidden="true">
+    <div class="gm-modal" role="dialog" aria-modal="true" aria-label="Ανάθεση χρήστη">
+      <h3>Ανάθεση χρήστη σε ομάδα</h3>
+      <p class="gm-help">Μπορείτε να αναθέσετε ρόλο μέλους ή διαχειριστή. Ο έλεγχος χρήστη γίνεται αυτόματα.</p>
+      <form id="assign-form" method="post" action="{{ url_for('auth.assign_user_to_group') }}">
+        <div class="gm-field">
+          <label for="assign-username">Username ή email χρήστη</label>
+          <input id="assign-username" type="text" name="username" placeholder="π.χ. maria ή maria@company.gr" required />
+          <div id="user-check-result" class="user-check-result"></div>
+        </div>
+        <div class="gm-field">
+          <label for="assign-group">Ομάδα</label>
+          <select id="assign-group" name="group" required>
+            <option value="">-- Επιλέξτε ομάδα --</option>
+            {% for g in admin_groups %}<option value="{{ g.name }}">{{ g.name }}</option>{% endfor %}
+          </select>
+        </div>
+        <div class="gm-field">
+          <label for="assign-role">Ρόλος</label>
+          <select id="assign-role" name="role">
+            <option value="member">Μέλος (πρόσβαση στα δεδομένα ομάδας)</option>
+            <option value="admin">Διαχειριστής (διαχείριση μελών + ομάδας)</option>
+          </select>
+        </div>
+        <div class="gm-actions">
+          <button type="button" id="close-assign" class="btn-ghost">Άκυρο</button>
+          <button type="submit" class="btn-primary">Εκτέλεση ανάθεσης</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script>
+    let checkTimeout;
+
+    function openModal(id){ const el=document.getElementById(id); if(el){ el.style.display='flex'; el.setAttribute('aria-hidden','false'); }}
+    function closeModal(id){ const el=document.getElementById(id); if(el){ el.style.display='none'; el.setAttribute('aria-hidden','true'); }}
+
+    document.getElementById('open-create')?.addEventListener('click', ()=> openModal('modal-create'));
+    document.getElementById('close-create')?.addEventListener('click', ()=> closeModal('modal-create'));
+    document.getElementById('open-assign')?.addEventListener('click', ()=> openModal('modal-assign'));
+    document.getElementById('close-assign')?.addEventListener('click', ()=> closeModal('modal-assign'));
+
+    document.querySelectorAll('.gm-modal-backdrop').forEach((backdrop)=>{
+      backdrop.addEventListener('click', (e)=>{ if(e.target === backdrop) backdrop.style.display='none'; });
+    });
+
+    document.getElementById('assign-username')?.addEventListener('input', function(){
+      const q = this.value.trim();
+      const out = document.getElementById('user-check-result');
+      if(checkTimeout) clearTimeout(checkTimeout);
+      if(!q){ out.textContent=''; return; }
+      out.textContent = 'Έλεγχος χρήστη...';
+      checkTimeout = setTimeout(async ()=>{
+        try{
+          const resp = await fetch("{{ url_for('auth.lookup_user') }}?q=" + encodeURIComponent(q));
+          const data = await resp.json();
+          out.innerHTML = (data.ok && data.found)
+            ? '<span style="color:#16a34a;">✓ Ο χρήστης βρέθηκε και μπορεί να ανατεθεί.</span>'
+            : '<span style="color:#f59e0b;">⚠ Δεν βρέθηκε χρήστης με αυτά τα στοιχεία.</span>';
+        }catch(_e){
+          out.innerHTML = '<span style="color:#ef4444;">✗ Αδυναμία ελέγχου χρήστη.</span>';
+        }
+      }, 400);
+    });
+
+    document.querySelectorAll('[data-group-card]').forEach((card)=>{
+      card.addEventListener('dblclick', ()=>{
+        const group = card.dataset.groupCard;
+        if(!group) return;
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = "{{ url_for('auth.select_group') }}";
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'group';
+        input.value = group;
+        form.appendChild(input);
+        document.body.appendChild(form);
+        form.submit();
+      });
+    });
+
+    document.querySelectorAll('.remove-member-btn').forEach((btn)=>{
+      btn.addEventListener('click', async (ev)=>{
+        ev.preventDefault();
+        const username = btn.dataset.username;
+        const group = btn.dataset.group;
+        const confirmed = await showModalConfirm('Επιβεβαίωση αφαίρεσης', 'Να αφαιρεθεί ο χρήστης ' + username + ' από την ομάδα ' + group + ';', 'Αφαίρεση', 'Άκυρο');
+        if(!confirmed) return;
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = "{{ url_for('auth.remove_member') }}";
+        const userInput = document.createElement('input');
+        userInput.type = 'hidden';
+        userInput.name = 'username';
+        userInput.value = username;
+        const groupInput = document.createElement('input');
+        groupInput.type = 'hidden';
+        groupInput.name = 'group';
+        groupInput.value = group;
+        form.appendChild(userInput);
+        form.appendChild(groupInput);
+        document.body.appendChild(form);
+        form.submit();
+      });
+    });
+
+    document.querySelectorAll('.leave-group-btn').forEach((btn)=>{
+      btn.addEventListener('click', async (ev)=>{
+        ev.preventDefault();
+        const group = btn.dataset.group;
+        const isAdmin = btn.dataset.isAdmin === 'true';
+        const title = isAdmin ? 'Διαγραφή ομάδας' : 'Αποχώρηση από ομάδα';
+        const message = isAdmin
+          ? 'Θέλετε να διαγράψετε την ομάδα ' + group + '; Η ενέργεια είναι οριστική.'
+          : 'Θέλετε να αποχωρήσετε από την ομάδα ' + group + ';';
+        const confirmText = isAdmin ? 'Διαγραφή' : 'Αποχώρηση';
+        const confirmed = await showModalConfirm(title, message, confirmText, 'Άκυρο');
+        if(!confirmed) return;
+        try{
+          const resp = await fetch("{{ url_for('auth.leave_group') }}", {
+            method:'POST',
+            headers:{'Content-Type':'application/x-www-form-urlencoded'},
+            body:'group='+encodeURIComponent(group)
+          });
+          const data = await resp.json();
+          if(data.ok){ window.location.reload(); }
+          else { await showModalAlert('Σφάλμα', (isAdmin ? 'Διαγραφή' : 'Αποχώρηση') + ' απέτυχε: ' + (data.error || 'άγνωστο σφάλμα')); }
+        }catch(_e){ await showModalAlert('Σφάλμα', 'Σφάλμα δικτύου'); }
+      });
+    });
+  </script>
+</div>
 {% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -5,17 +5,24 @@
 
 <!-- No active credential warning -->
 {% if not active_credential %}
-<div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-4">
+<style>
+  .missing-customer-warning { background: #fffbeb; border-left: 4px solid #f59e0b; color: #78350f; }
+  .missing-customer-warning a { color: #92400e; }
+  [data-theme="dark"] .missing-customer-warning { background: #3b2f00; border-left-color: #fbbf24; color: #fde68a; }
+  [data-theme="dark"] .missing-customer-warning a { color: #fcd34d; }
+  [data-theme="dark"] .missing-customer-warning svg { color: #fbbf24; }
+</style>
+<div class="missing-customer-warning p-4 mb-4 rounded-r-lg">
   <div class="flex items-center">
     <div class="flex-shrink-0">
-      <svg class="h-5 w-5 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <svg class="h-5 w-5 text-yellow-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
         <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
       </svg>
     </div>
     <div class="ml-3">
-      <p class="text-sm text-yellow-700">
+      <p class="text-sm">
         <strong>Δεν έχει επιλεγεί ενεργός πελάτης.</strong> 
-        <a href="{{ url_for('credentials') }}" class="font-medium underline text-yellow-700 hover:text-yellow-600">Επιλέξτε πελάτη</a> για να συνεχίσετε.
+        <a href="{{ url_for('credentials') }}" class="font-medium underline">Επιλέξτε πελάτη</a> για να συνεχίσετε.
       </p>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Support tickets delivered via the Discord/webhook bridge were not always resolved correctly and `support_typing` state used string comparison, causing visibility/typing/read status inconsistencies.
- The yellow “no active customer” warning was low-contrast in dark mode and hard to read.
- The Groups management UX needed a clearer, more user-friendly layout and more informative modals for creating groups and assigning users.

### Description
- Added `_support_find_ticket_for_payload` in `app.py` to resolve tickets from multiple payload keys (`ticket_id`, `ticket`, `id`, `discord_thread_id`, `thread_id`, `channel_id`) to make webhook payloads more tolerant and reliable.
- Added `_support_parse_iso_utc` in `app.py` and switched `support_typing` calculation to parse and compare UTC datetimes instead of lexicographic string comparison to fix typing-presence reliability.
- Introduced `action_aliases` mapping in `api_support_discord_reply` to accept common webhook action variants (e.g. `typing`, `typing_on`, `typing_off`, `mark_read`, `seen`) so the bridge updates typing/read/close reliably.
- Improved the no-active-customer warning in `templates/search.html` by replacing the inline yellow box with a `.missing-customer-warning` CSS + markup that has high-contrast colors for dark mode and readable link/icon colors.
- Rewrote `templates/auth/groups.html` to a card-based layout with clearer hierarchy (cards, pills, badges), more detailed and accessible `Create group` and `Assign user` modals, and cleaned-up JavaScript wiring while preserving existing behaviors (double-click select, remove member, leave/delete group, live user lookup).

### Testing
- Compiled Python sources with `python3 -m py_compile app.py auth.py`, which completed successfully.
- Attempted to run the app (`python3 app.py`) to validate runtime UI behavior, but startup failed in the local environment due to a missing dependency (`werkzeug`), so full end-to-end UI runtime tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698efe3f64bc832898f6c98c6a8286b5)