### PR TITLE
Improve Epsilon preview diffs, support ticket UX, and admin activity cleanup

### DIFF
--- a/app.py
+++ b/app.py
@@ -1873,8 +1873,6 @@ def _looks_like_receipt(rec: dict) -> bool:
 def _collect_missing_afm_from_preview(rows):
     missing = {}
     for r in rows or []:
-        if not _looks_like_receipt(r):
-            continue
         cid = r.get("CUSTID")
         if cid not in (None, "", 0):
             continue
@@ -10555,7 +10553,22 @@ def api_support_my_ticket():
     data = _support_load()
     ticket = _support_get_my_open_ticket(data, user_id)
     if not ticket:
-        return jsonify({"ok": True, "ticket": None, "messages": [], "presence": {"support_typing": False}})
+        user_tickets = [t for t in (data.get("tickets") or []) if str(t.get("user_id") or "") == user_id]
+        if not user_tickets:
+            return jsonify({"ok": True, "ticket": None, "messages": [], "presence": {"support_typing": False}})
+
+        user_tickets.sort(key=lambda x: str(x.get("updated_at") or x.get("created_at") or ""), reverse=True)
+        latest = user_tickets[0]
+        latest_msgs = [m for m in (data.get("messages") or []) if int(m.get("ticket_id") or 0) == int(latest.get("id") or 0)]
+        latest_msgs.sort(key=lambda x: str(x.get("timestamp") or ""))
+        closed_notice = bool(str(latest.get("status") or "").lower() == "closed" and str(latest.get("closed_by") or "") in ("admin", "support", "admin/support"))
+        return jsonify({
+            "ok": True,
+            "ticket": latest,
+            "messages": latest_msgs[-100:],
+            "presence": {"support_typing": False},
+            "closed_notice": closed_notice,
+        })
 
     # Pull direct Discord thread replies (admin/mod messages) even if webhook bridge did not post them.
     _support_discord_sync_thread_messages(data, ticket)
@@ -11527,6 +11540,7 @@ def epsilon_preview():
 
     # Έλεγχος ασυμφωνίας: εγγραφές στο epsilon json που δεν υπάρχουν στο invoices.xlsx
     missing_excel_marks: List[str] = []
+    missing_excel_rows: List[Dict[str, Any]] = []
     try:
         excel_path = excel_path_for(vat=vat)
         if os.path.exists(excel_path):
@@ -11534,6 +11548,22 @@ def epsilon_preview():
             excel_marks = set(df_excel.get("MARK", pd.Series(dtype=str)).astype(str).str.strip().tolist())
             preview_marks = [str(r.get("MARK") or "").strip() for r in (rows or []) if str(r.get("MARK") or "").strip()]
             missing_excel_marks = sorted({m for m in preview_marks if m not in excel_marks})
+            if missing_excel_marks:
+                rows_by_mark: Dict[str, List[Dict[str, Any]]] = {}
+                for r in (rows or []):
+                    mk = str(r.get("MARK") or "").strip()
+                    if not mk:
+                        continue
+                    rows_by_mark.setdefault(mk, []).append(r)
+                for mk in missing_excel_marks:
+                    for rec in rows_by_mark.get(mk, [{}]):
+                        missing_excel_rows.append({
+                            "mark": mk,
+                            "aa": str(rec.get("AA") or "").strip(),
+                            "afm": str(rec.get("AFM_ISSUER") or "").strip(),
+                            "issuer_name": str(rec.get("ISSUER_NAME") or "").strip(),
+                            "date": str(rec.get("DATE") or "").strip(),
+                        })
     except Exception:
         current_app.logger.exception("Failed to compare epsilon preview against excel MARK column")
 
@@ -11544,7 +11574,8 @@ def epsilon_preview():
                            bridge_ok=(not issues and len(rows)>0),
                            bridge_issues=issues,
                            category_labels=category_labels,
-                           missing_excel_marks=missing_excel_marks)
+                           missing_excel_marks=missing_excel_marks,
+                           missing_excel_rows=missing_excel_rows)
 
 
 @app.route("/export/fastimport/kinitseis")
@@ -12355,6 +12386,134 @@ def api_admin_activity_logs():
     
     logs = admin_panel.admin_get_activity_logs(group_name, limit)
     return jsonify({'logs': logs})
+
+
+@app.route('/api/admin/activity-logs/clear', methods=['POST'])
+@login_required
+def api_admin_activity_logs_clear():
+    if not admin_panel.is_admin(current_user):
+        return jsonify({'ok': False, 'error': 'Admin access required'}), 403
+
+    payload = request.get_json(silent=True) or {}
+    period = str(payload.get('period') or '').strip().lower()
+    start_date = str(payload.get('start_date') or '').strip()
+    end_date = str(payload.get('end_date') or '').strip()
+
+    now = datetime.now(timezone.utc)
+    cutoff_start = None
+    cutoff_end = None
+
+    def _sub_months(dt: datetime, months: int) -> datetime:
+        y = dt.year
+        m = dt.month - months
+        while m <= 0:
+            y -= 1
+            m += 12
+        import calendar
+        d = min(dt.day, calendar.monthrange(y, m)[1])
+        return dt.replace(year=y, month=m, day=d)
+
+    try:
+        if period in ('1m', '2m', '3m'):
+            cutoff_start = _sub_months(now, int(period[0]))
+        elif period == 'custom':
+            if not start_date or not end_date:
+                return jsonify({'ok': False, 'error': 'Απαιτούνται start_date και end_date για custom διάστημα.'}), 400
+            cutoff_start = datetime.fromisoformat(start_date).replace(tzinfo=timezone.utc)
+            cutoff_end = datetime.fromisoformat(end_date).replace(tzinfo=timezone.utc)
+            cutoff_end = cutoff_end.replace(hour=23, minute=59, second=59)
+        else:
+            return jsonify({'ok': False, 'error': 'Μη έγκυρο period. Επιτρεπτά: 1m, 2m, 3m, custom'}), 400
+    except Exception:
+        return jsonify({'ok': False, 'error': 'Μη έγκυρες ημερομηνίες.'}), 400
+
+    def _parse_ts(ts: str):
+        if not ts:
+            return None
+        variants = [str(ts).strip(), str(ts).strip().replace('Z', '+00:00')]
+        for v in variants:
+            try:
+                dt = datetime.fromisoformat(v)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt.astimezone(timezone.utc)
+            except Exception:
+                continue
+        return None
+
+    def _should_delete(dt: datetime) -> bool:
+        if not dt:
+            return False
+        if cutoff_end is not None:
+            return cutoff_start <= dt <= cutoff_end
+        return dt >= cutoff_start
+
+    total_deleted = 0
+    groups = Group.query.all()
+    for grp in groups:
+        folder = getattr(grp, 'data_folder', None) or grp.name
+
+        # Firebase activity logs per group
+        try:
+            path = f'/activity_logs/{folder}'
+            remote = firebase_config.firebase_read_data(path) or {}
+            if isinstance(remote, dict):
+                kept = {}
+                for key, val in remote.items():
+                    ts = _parse_ts((val or {}).get('timestamp') if isinstance(val, dict) else '')
+                    if _should_delete(ts):
+                        total_deleted += 1
+                    else:
+                        kept[key] = val
+                firebase_config.firebase_delete_data(path)
+                if kept:
+                    firebase_config.firebase_write_data(path, kept)
+        except Exception:
+            current_app.logger.exception('Failed clearing Firebase activity logs for %s', folder)
+
+        # Local JSONL/plain file fallback logs
+        try:
+            group_dir = os.path.join(os.getcwd(), 'data', str(folder))
+            for file_name in ('activity.log.jsonl', 'activity.log'):
+                fpath = os.path.join(group_dir, file_name)
+                if not os.path.exists(fpath):
+                    continue
+                kept_lines = []
+                with open(fpath, 'r', encoding='utf-8') as fh:
+                    for line in fh:
+                        line_stripped = line.strip()
+                        if not line_stripped:
+                            continue
+                        parsed = None
+                        ts = None
+                        try:
+                            parsed = json.loads(line_stripped)
+                            if isinstance(parsed, dict):
+                                ts = _parse_ts(parsed.get('timestamp') or '')
+                        except Exception:
+                            parsed = None
+                        if ts is None and ' - ' in line_stripped:
+                            ts = _parse_ts(line_stripped.split(' - ', 1)[0])
+                        if _should_delete(ts):
+                            total_deleted += 1
+                            continue
+                        kept_lines.append(line)
+                with open(fpath, 'w', encoding='utf-8') as fw:
+                    fw.writelines(kept_lines)
+        except Exception:
+            current_app.logger.exception('Failed clearing local activity logs for %s', folder)
+
+    try:
+        firebase_config.firebase_log_activity(str(getattr(current_user, 'id', 'admin')), 'admin', 'activity_logs_cleared', {
+            'period': period,
+            'start_date': start_date,
+            'end_date': end_date,
+            'deleted_entries': total_deleted,
+        })
+    except Exception:
+        pass
+
+    return jsonify({'ok': True, 'deleted_entries': total_deleted})
 
 
 @app.route("/admin/send-email", methods=['GET', 'POST'])

--- a/templates/admin/dashboard_unified.html
+++ b/templates/admin/dashboard_unified.html
@@ -1751,16 +1751,101 @@ async function testEmailConfiguration() {
 }
 
 async function clearActivityLogsConfirm() {
-  if (!await showModalConfirm('Διαγραφή Activity Logs', 'Είστε σίγουρος; Αυτό δεν μπορεί να αναιρεθεί.', 'Διαγραφή', 'Άκυρο')) return;
-  clearActivityLogs();
+  const choice = await showActivityDeleteRangeModal();
+  if (!choice) return;
+  clearActivityLogs(choice);
 }
 
-async function clearActivityLogs() {
+function showActivityDeleteRangeModal() {
+  return new Promise((resolve) => {
+    const modal = document.createElement('div');
+    modal.className = 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50';
+    modal.innerHTML = `
+      <div class="bg-white rounded-lg p-6 max-w-lg w-full mx-4">
+        <div class="flex items-center mb-4">
+          <div class="text-red-600 text-2xl mr-3">⚠️</div>
+          <h3 class="text-lg font-bold">Διαγραφή Δραστηριότητας</h3>
+        </div>
+        <p class="text-gray-700 mb-4">Επέλεξε για ποιο διάστημα θέλεις να διαγράψεις activity logs:</p>
+
+        <div class="space-y-2 mb-4 text-sm">
+          <label class="flex items-center gap-2"><input type="radio" name="activity-delete-period" value="1m" checked> Τελευταίος 1 μήνας</label>
+          <label class="flex items-center gap-2"><input type="radio" name="activity-delete-period" value="2m"> Τελευταίοι 2 μήνες</label>
+          <label class="flex items-center gap-2"><input type="radio" name="activity-delete-period" value="3m"> Τελευταίοι 3 μήνες</label>
+          <label class="flex items-center gap-2"><input type="radio" name="activity-delete-period" value="custom"> Custom ημερομηνίες</label>
+        </div>
+
+        <div id="customActivityRange" class="hidden grid grid-cols-1 md:grid-cols-2 gap-3 mb-4">
+          <div>
+            <label class="block text-xs text-gray-500 mb-1">Από</label>
+            <input id="activityDeleteStartDate" type="date" class="w-full px-3 py-2 border rounded">
+          </div>
+          <div>
+            <label class="block text-xs text-gray-500 mb-1">Έως</label>
+            <input id="activityDeleteEndDate" type="date" class="w-full px-3 py-2 border rounded">
+          </div>
+        </div>
+
+        <div class="flex gap-3 justify-end">
+          <button id="activityDeleteCancelBtn" class="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400">Ακύρωση</button>
+          <button id="activityDeleteConfirmBtn" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">Διαγραφή</button>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(modal);
+
+    const periodInputs = modal.querySelectorAll('input[name="activity-delete-period"]');
+    const customWrap = modal.querySelector('#customActivityRange');
+    const startInput = modal.querySelector('#activityDeleteStartDate');
+    const endInput = modal.querySelector('#activityDeleteEndDate');
+
+    const updateCustomVisibility = () => {
+      const selected = modal.querySelector('input[name="activity-delete-period"]:checked')?.value;
+      customWrap.classList.toggle('hidden', selected !== 'custom');
+    };
+    periodInputs.forEach(inp => inp.addEventListener('change', updateCustomVisibility));
+    updateCustomVisibility();
+
+    modal.querySelector('#activityDeleteCancelBtn')?.addEventListener('click', () => {
+      modal.remove();
+      resolve(null);
+    });
+
+    modal.querySelector('#activityDeleteConfirmBtn')?.addEventListener('click', () => {
+      const selected = modal.querySelector('input[name="activity-delete-period"]:checked')?.value || '1m';
+      if (selected === 'custom') {
+        if (!startInput.value || !endInput.value) {
+          showErrorModal('❌ Λείπουν ημερομηνίες', 'Συμπλήρωσε ημερομηνίες για custom διάστημα.');
+          return;
+        }
+      }
+      modal.remove();
+      resolve({
+        period: selected,
+        start_date: startInput.value || null,
+        end_date: endInput.value || null,
+      });
+    });
+  });
+}
+
+async function clearActivityLogs(rangePayload) {
   try {
-    // TODO: Implement clear activity logs
-    showErrorModal('🚧 Not Implemented', 'Clear activity logs feature not yet implemented');
+    const response = await fetch('/api/admin/activity-logs/clear', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rangePayload || { period: '1m' })
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data.ok) {
+      throw new Error(data.error || 'Αποτυχία διαγραφής logs');
+    }
+    showSuccessModal('✅ Ολοκληρώθηκε', `Διαγράφηκαν ${data.deleted_entries || 0} εγγραφές δραστηριότητας.`);
+    loadActivity();
+    loadStats();
   } catch (err) {
-    showErrorModal('❌ Σφάλμα', 'Error clearing logs');
+    showErrorModal('❌ Σφάλμα', err.message || 'Error clearing logs');
   }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -2991,7 +2991,22 @@ html[data-theme="dark"] #helpBotPresence,html[data-theme="dark"] #helpBotFileSta
   let lastPresence={support_typing:false};
   const NAME_KEY='support_display_name';
   const SEEN_KEY='support_last_seen';
+  const CLOSED_NOTICE_KEY='support_closed_notice_seen';
   let lastTicket=null;
+
+  function updateNameFieldState(ticket){
+    if(!nameInput) return;
+    const hasLockedName = !!(ticket && (ticket.id || ticket.display_name));
+    if(hasLockedName){
+      const who = String(ticket.display_name || nameInput.value || '').trim();
+      if(who) nameInput.value = who;
+      nameInput.disabled = true;
+      nameInput.style.display = 'none';
+    } else {
+      nameInput.disabled = false;
+      nameInput.style.display = '';
+    }
+  }
 
   function esc(s){return String(s||'').replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;');}
   function formatStatus(m){
@@ -3082,8 +3097,18 @@ html[data-theme="dark"] #helpBotPresence,html[data-theme="dark"] #helpBotFileSta
       lastTicket = j.ticket || null;
       lastPresence = j.presence || {support_typing:false};
       updateTitle(lastTicket);
+      updateNameFieldState(lastTicket);
       render(j.messages||[]);
       updateBadge(j.messages||[]);
+      if (j.closed_notice && open && lastTicket && String(lastTicket.status||'') === 'closed') {
+        const noticeKey = `${CLOSED_NOTICE_KEY}:${lastTicket.id || '0'}:${lastTicket.closed_at || ''}`;
+        const already = localStorage.getItem(noticeKey);
+        if(!already){
+          const by = String(lastTicket.closed_by || 'support');
+          alert(`Το ticket έκλεισε από ${by === 'admin' ? 'admin/support' : by}. Μπορείς να ξεκινήσεις νέο ticket στέλνοντας νέο μήνυμα.`);
+          localStorage.setItem(noticeKey, '1');
+        }
+      }
       updatePresence();
       if(open){ markSeen(j.messages||[]); }
     }catch(_e){}
@@ -3128,6 +3153,7 @@ html[data-theme="dark"] #helpBotPresence,html[data-theme="dark"] #helpBotFileSta
     const savedName = localStorage.getItem(NAME_KEY) || '';
     if(savedName && nameInput) nameInput.value = savedName;
   }catch(_e){}
+  updateNameFieldState(null);
   closeBtn&&closeBtn.addEventListener('click',()=>setOpen(false));
 
   refresh();

--- a/templates/epsilon_preview.html
+++ b/templates/epsilon_preview.html
@@ -15,6 +15,8 @@
 .btn:disabled{opacity:.5;cursor:not-allowed}
 .btn-primary{background:#0ea5e9;color:#fff;border-color:#0ea5e9}
 .btn-danger{background:#ef4444;color:#fff;border-color:#ef4444}
+.btn-link{border:none;background:transparent;color:#1d4ed8;text-decoration:underline;cursor:pointer;padding:0}
+.count-highlight{display:inline-flex;align-items:center;justify-content:center;min-width:22px;padding:2px 8px;border-radius:999px;background:#b91c1c;color:#fff;font-weight:700;box-shadow:0 0 0 3px rgba(239,68,68,.25)}
 
 /* Dark mode table styling */
 [data-theme="dark"] #epsilonTable {
@@ -70,6 +72,17 @@
   </div>
 </div>
 
+<!-- Epsilon vs Excel diffs modal -->
+<div id="missingMarksModal" class="fixed inset-0 bg-black/50 hidden items-center justify-center z-50">
+  <div class="bg-white rounded-xl shadow-xl max-w-3xl w-[92vw] p-4">
+    <div class="flex items-center justify-between mb-2">
+      <h3 class="text-lg font-semibold">Διαφορές epsilon json ↔ invoices.xlsx</h3>
+      <button id="missingMarksCloseBtn" class="px-2 py-1 border rounded">Κλείσιμο</button>
+    </div>
+    <div id="missingMarksList" class="max-h-[60vh] overflow-auto space-y-2 text-sm"></div>
+  </div>
+</div>
+
 <div class="bg-white rounded shadow p-6">
   <div class="flex items-center justify-between mb-4">
     <div class="flex items-center gap-3">
@@ -90,7 +103,11 @@
 
   {% if missing_excel_marks %}
     <div class="mb-3 p-3 rounded border border-amber-300 bg-amber-50 text-amber-900 text-sm">
-      Εντοπίστηκαν <strong>{{ missing_excel_marks|length }}</strong> παραστατικά στο epsilon json που δεν υπάρχουν στο invoices.xlsx.
+      Εντοπίστηκαν
+      <button type="button" id="openMissingMarksModal" class="btn-link align-baseline" title="Προβολή λίστας διαφορών">
+        <span class="count-highlight">{{ missing_excel_marks|length }}</span>
+      </button>
+      παραστατικά στο epsilon json που δεν υπάρχουν στο invoices.xlsx.
       Μπορείς να τα αφαιρέσεις προσωρινά από την προεπισκόπηση με το κουμπί «Διαγραφή».
     </div>
   {% endif %}
@@ -214,6 +231,7 @@ const TABLE_DATA = {{ table_rows|tojson|safe }};
 const ACTIVE_VAT = "{{ vat or '' }}";
 const BRIDGE_ISSUES = {{ (bridge_issues or [])|tojson|safe }};
 const CATEGORY_LABELS = {{ (category_labels or {})|tojson|safe }};
+const MISSING_EXCEL_ROWS = {{ (missing_excel_rows or [])|tojson|safe }};
 const EXCLUDED_MARKS = new Set();
 
 function money(n){
@@ -665,6 +683,41 @@ $(function(){
     }).join('');
     wrap.classList.remove('hidden'); wrap.classList.add('flex');
     document.getElementById('issuesCloseBtn')?.addEventListener('click', ()=> wrap.classList.add('hidden'));
+  })();
+
+  (function(){
+    const openBtn = document.getElementById('openMissingMarksModal');
+    const wrap = document.getElementById('missingMarksModal');
+    const closeBtn = document.getElementById('missingMarksCloseBtn');
+    const list = document.getElementById('missingMarksList');
+    if(!openBtn || !wrap || !list) return;
+
+    const rows = Array.isArray(MISSING_EXCEL_ROWS) ? MISSING_EXCEL_ROWS : [];
+    list.innerHTML = rows.length
+      ? rows.map((r, idx) => {
+          const mark = String(r.mark || '');
+          const aa = String(r.aa || '—');
+          const afm = String(r.afm || '—');
+          const name = String(r.issuer_name || '—').replace(/</g,'&lt;');
+          const date = String(r.date || '—');
+          return `<div class="p-2 rounded border bg-amber-50 border-amber-200">${idx+1}. MARK=<strong>${mark}</strong> · AA=${aa} · ΑΦΜ=${afm} · ${name} · ${date}</div>`;
+        }).join('')
+      : '<div class="p-2 rounded border bg-gray-50 border-gray-200">Δεν υπάρχουν διαθέσιμες λεπτομέρειες.</div>';
+
+    const closeModal = () => {
+      wrap.classList.add('hidden');
+      wrap.classList.remove('flex');
+    };
+    const openModal = () => {
+      wrap.classList.remove('hidden');
+      wrap.classList.add('flex');
+    };
+
+    openBtn.addEventListener('click', openModal);
+    closeBtn?.addEventListener('click', closeModal);
+    wrap.addEventListener('click', (e) => {
+      if(e.target === wrap) closeModal();
+    });
   })();
 });
 </script>


### PR DESCRIPTION
### Motivation
- Make it easier to spot and inspect invoices present in the epsilon JSON but missing from `invoices.xlsx` and allow safer temporary removal from preview before export.
- Allow bridge export partner-creation to work for missing `CUSTID` across all preview rows (not only receipt-like rows).
- Improve support chat UX so display name is locked after ticket creation and users are informed when an admin/support closes a ticket.
- Provide admins a safe UI+API to delete activity logs for a chosen interval (preset months or custom range) and remove matching Firebase/local entries.

### Description
- Backend: add `missing_excel_rows` in `epsilon_preview()` and collect per-MARK details (AA, AFM, issuer name, date) to pass to the template (`app.py`).
- UI (epsilon): highlight the missing count, add a clickable badge and a `missingMarksModal` showing the detailed per-MARK differences, and inject `MISSING_EXCEL_ROWS` into the page (`templates/epsilon_preview.html`).
- Bridge/export: relax the `_collect_missing_afm_from_preview` logic so missing `CUSTID` AFMs are collected from all preview rows (not just receipts) to allow the AFM-mode partner creation flow to run for affected AFMs (`app.py` / `epsilon_bridge_multiclient_strict` integration points remain unchanged).
- Support chat: lock/hide the display-name input once a ticket exists and surface the most-recent closed ticket to users when no open ticket exists, plus a client-side alert when admin/support closes a ticket (`app.py` changes to `/api/support/ticket/me` and `templates/base.html` JS updates).
- Admin: add a dashboard modal to choose a deletion interval (1/2/3 months or custom dates) and implement `POST /api/admin/activity-logs/clear` which prunes Firebase activity entries and local fallback logs (`app.py` + `templates/admin/dashboard_unified.html`).

### Testing
- Compiled key modules successfully with `python3 -m py_compile app.py admin_panel.py admin_api.py epsilon_bridge_multiclient_strict.py` (succeeded).
- Attempted to run the app with `python3 app.py` to validate runtime behavior, but startup failed in this environment due to a missing runtime dependency (`werkzeug`), so end-to-end server tests were not executed (observed failure: ModuleNotFoundError: No module named 'werkzeug').

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69930aa938f48328b2725c75c28680ca)